### PR TITLE
Add bluefilter / night light detection module

### DIFF
--- a/AutoDarkModeApp/App.config
+++ b/AutoDarkModeApp/App.config
@@ -5,7 +5,7 @@
             <section name="AutoDarkModeApp.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
-    <startup> 
+    <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
     <userSettings>
@@ -40,6 +40,9 @@
             <setting name="WallpaperSwitch" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="WallpaperBluelight" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="AlterTime" serializeAs="String">
                 <value>False</value>
             </setting>
@@ -70,6 +73,9 @@
             <setting name="ThemeSwitch" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ThemeBluelight" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="AccentColorSwitchTime" serializeAs="String">
                 <value>800</value>
             </setting>
@@ -94,17 +100,20 @@
             <setting name="TaskFolderTitleMultiUser" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LanguageChanged" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="UIScale" serializeAs="String">
                 <value>1</value>
             </setting>
         </AutoDarkModeApp.Properties.Settings>
     </userSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.WindowsRuntime" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.WindowsRuntime" publicKeyToken="b77a5c561934e089" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/AutoDarkModeApp/Extensions.cs
+++ b/AutoDarkModeApp/Extensions.cs
@@ -8,7 +8,8 @@ namespace AutoDarkModeSvc
     {
         Switch = 0,
         LightOnly = 1,
-        DarkOnly = 2
+        DarkOnly = 2,
+        Bluelight = 3
     };
     public enum Theme
     {

--- a/AutoDarkModeApp/Extensions.cs
+++ b/AutoDarkModeApp/Extensions.cs
@@ -8,8 +8,7 @@ namespace AutoDarkModeSvc
     {
         Switch = 0,
         LightOnly = 1,
-        DarkOnly = 2,
-        BlueLight = 3
+        DarkOnly = 2
     };
     public enum Theme
     {

--- a/AutoDarkModeApp/Extensions.cs
+++ b/AutoDarkModeApp/Extensions.cs
@@ -8,7 +8,8 @@ namespace AutoDarkModeSvc
     {
         Switch = 0,
         LightOnly = 1,
-        DarkOnly = 2
+        DarkOnly = 2,
+        BlueLight = 3
     };
     public enum Theme
     {

--- a/AutoDarkModeApp/Handlers/RegEditHandler.cs
+++ b/AutoDarkModeApp/Handlers/RegEditHandler.cs
@@ -230,15 +230,13 @@ namespace AutoDarkModeApp
         //get if the nightlight is enabled
         public bool IsNightLightEnabled()
         {
-            const string BlueLightReductionStateKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate";
-            using (var key = Registry.CurrentUser.OpenSubKey(BlueLightReductionStateKey))
-            {
-                var data = key?.GetValue("Data");
-                if (data is null)
-                    return false;
-                var byteData = (byte[])data;
-                return byteData.Length > 24 && byteData[23] == 0x10 && byteData[24] == 0x00;
-            }
+            using var key = GetBluelightKey();
+
+            var data = key?.GetValue("Data");
+            if (data is null)
+                return false;
+            var byteData = (byte[])data;
+            return !(byteData.Length > 24 && byteData[23] == 0x10 && byteData[24] == 0x00);
         }
 
         //get windows version number, like 1607 or 1903
@@ -251,6 +249,15 @@ namespace AutoDarkModeApp
         private RegistryKey GetPersonalizeKey()
         {
             RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", true);
+            return registryKey;
+        }
+
+        //gets the current user's bluelight registry key
+        private static RegistryKey GetBluelightKey()
+        {
+            RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(
+                @"SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate",
+                true);
             return registryKey;
         }
 

--- a/AutoDarkModeApp/Handlers/RegEditHandler.cs
+++ b/AutoDarkModeApp/Handlers/RegEditHandler.cs
@@ -226,6 +226,21 @@ namespace AutoDarkModeApp
             var keyValue = GetPersonalizeKey().GetValue("SystemUsesLightTheme");
             return ((int)keyValue == 1) ? true : false;
         }
+
+        //get if the nightlight is enabled
+        public bool IsNightLightEnabled()
+        {
+            const string BlueLightReductionStateKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate";
+            using (var key = Registry.CurrentUser.OpenSubKey(BlueLightReductionStateKey))
+            {
+                var data = key?.GetValue("Data");
+                if (data is null)
+                    return false;
+                var byteData = (byte[])data;
+                return byteData.Length > 24 && byteData[23] == 0x10 && byteData[24] == 0x00;
+            }
+        }
+
         //get windows version number, like 1607 or 1903
         public string GetOSversion()
         {

--- a/AutoDarkModeApp/Pages/PageApps.xaml
+++ b/AutoDarkModeApp/Pages/PageApps.xaml
@@ -30,6 +30,7 @@
             <ComboBoxItem IsSelected="True" Content="{x:Static p:Resources.cmbAdjTheme}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwWhite}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwDark}"/>
+            <ComboBoxItem Content="{x:Static p:Resources.cmbAlwBluelight}"/>
         </ComboBox>
 
         <!-- System -->
@@ -39,6 +40,7 @@
             <ComboBoxItem IsSelected="True" Content="{x:Static p:Resources.cmbAdjTheme}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwWhite}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwDark}"/>
+            <ComboBoxItem Content="{x:Static p:Resources.cmbAlwBluelight}"/>
         </ComboBox>
         <CheckBox x:Name="AccentColorCheckBox" Content="{x:Static p:Resources.cmbAccentColor}" Foreground="{DynamicResource SystemBaseHighColorBrush}" HorizontalAlignment="Left" Margin="49,179,0,0" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1"  Click="AccentColorCheckBox_Click" ToolTipService.ShowOnDisabled="true" ToolTipService.InitialShowDelay="3" ToolTipService.HasDropShadow="True" Height="Auto" Width="Auto"/>
 
@@ -49,6 +51,7 @@
             <ComboBoxItem IsSelected="True" Content="{x:Static p:Resources.cmbAdjTheme}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwWhite}"/>
             <ComboBoxItem Content="{x:Static p:Resources.cmbAlwDark}"/>
+            <ComboBoxItem Content="{x:Static p:Resources.cmbAlwBluelight}"/>
             <ComboBoxItem Content="{x:Static p:Resources.disabled}"/>
         </ComboBox>
         <CheckBox Content="{x:Static p:Resources.cbOfficeWhiteTheme}" x:Name="CheckBoxOfficeWhiteTheme" Grid.Column="1" Grid.Row="1"  Margin="49,266,0,0" Width="Auto" Height="Auto" VerticalAlignment="Top" HorizontalAlignment="Left" Foreground="{DynamicResource SystemBaseHighColorBrush}" Click="CheckBoxOfficeWhiteTheme_Click"/>

--- a/AutoDarkModeApp/Pages/PageApps.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageApps.xaml.cs
@@ -103,7 +103,7 @@ namespace AutoDarkModeApp
             }
             else
             {
-                OfficeComboBox.SelectedIndex = 3;
+                OfficeComboBox.SelectedIndex = 4;
             }
 
 
@@ -129,6 +129,11 @@ namespace AutoDarkModeApp
             if (AppComboBox.SelectedIndex.Equals(2))
             {
                 builder.Config.AppsTheme = Mode.DarkOnly;
+            }
+
+            if (AppComboBox.SelectedIndex.Equals(3))
+            {
+                builder.Config.AppsTheme = Mode.Bluelight;
             }
             try
             {
@@ -160,6 +165,12 @@ namespace AutoDarkModeApp
                 builder.Config.SystemTheme = Mode.DarkOnly;
                 Properties.Settings.Default.SystemThemeChange = 2;
                 AccentColorCheckBox.IsEnabled = true;
+            }
+
+            if (SystemComboBox.SelectedIndex.Equals(3))
+            {
+                builder.Config.SystemTheme = Mode.Bluelight;
+                AccentColorCheckBox.IsEnabled = false;
             }
             try
             {
@@ -213,6 +224,11 @@ namespace AutoDarkModeApp
 
             if (OfficeComboBox.SelectedIndex.Equals(3))
             {
+                builder.Config.Office.Mode = Mode.Bluelight;
+            }
+
+            if (OfficeComboBox.SelectedIndex.Equals(4))
+            {
                 builder.Config.Office.Enabled = false;
             }
             try
@@ -228,8 +244,8 @@ namespace AutoDarkModeApp
         private void DisableOfficeSwitch()
         {
             //does nothing for now
-            Properties.Settings.Default.OfficeThemeChange = 3;
-            OfficeComboBox.SelectedIndex = 3;
+            Properties.Settings.Default.OfficeThemeChange = 4;
+            OfficeComboBox.SelectedIndex = 4;
         }
 
         private void ButtonWikiBrowserExtension_Click(object sender, RoutedEventArgs e)

--- a/AutoDarkModeApp/Pages/PageTime.xaml
+++ b/AutoDarkModeApp/Pages/PageTime.xaml
@@ -40,6 +40,7 @@
         <StackPanel Name="StackPanelRadioHolder"  Grid.Row="3" Grid.Column="1" Margin="10,0,0,0" Orientation="Vertical"  VerticalAlignment="Top" HorizontalAlignment="Left" Width="Auto" Height="Auto">
             <RadioButton Name="RadioButtonCustomTimes"  Content="{x:Static p:Resources.rbCustomHours}" IsChecked="True" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,0,0,0" Foreground="{DynamicResource SystemBaseHighColorBrush}" Click="RadioButtonCustomTimes_Click"/>
             <RadioButton Name="RadioButtonLocationTimes" Content="{x:Static p:Resources.rbLocation}" IsChecked="False" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,10,0,0" Foreground="{DynamicResource SystemBaseHighColorBrush}" Click="RadioButtonLocationTimes_Click"/>
+            <RadioButton Name="RadioButtonBluelight" Content="{x:Static p:Resources.rbBluelight}" IsChecked="False" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,10,0,0" Foreground="{DynamicResource SystemBaseHighColorBrush}" Click="RadioButtonBluelight_Click"/>
         </StackPanel>
         
         <!-- Time selection -->

--- a/AutoDarkModeApp/Pages/PageTime.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageTime.xaml.cs
@@ -37,9 +37,19 @@ namespace AutoDarkModeApp.Pages
                 ShowErrorMessage(ex);
             }
             InitializeComponent();
-            if (builder.Config.AutoThemeSwitchingEnabled)
+            //eventually set these based on StackPanelRadioHolder
+            if (builder.Config.TimeSwitchingEnabled)
             {
+                DisableLocationMode();
+                builder.Config.BlueLightSwitchingEnabled = false;
                 autoCheckBox.IsChecked = true;
+            }
+            if (builder.Config.BlueLightSwitchingEnabled)
+            {
+                DisableLocationMode();
+                builder.Config.TimeSwitchingEnabled = false;
+                autoCheckBox.IsChecked = true;
+                RadioButtonBluelight.IsChecked = true;
             }
             if (builder.Config.Location.Enabled)
             {
@@ -479,6 +489,8 @@ namespace AutoDarkModeApp.Pages
             if (e != null && !init)
             {
                 builder.Config.AutoThemeSwitchingEnabled = false;
+                builder.Config.TimeSwitchingEnabled = false;
+                builder.Config.BlueLightSwitchingEnabled = false;
                 try
                 {
                     builder.Save();
@@ -575,6 +587,11 @@ namespace AutoDarkModeApp.Pages
         {
             builder.Config.Location.Enabled = true;
             ApplyTheme();
+        }
+
+        private void RadioButtonBluelight_Click(object sender, RoutedEventArgs e)
+        {
+            DisableLocationMode();
         }
 
         //textbox event handlers

--- a/AutoDarkModeApp/Properties/Resources.Designer.cs
+++ b/AutoDarkModeApp/Properties/Resources.Designer.cs
@@ -244,6 +244,15 @@ namespace AutoDarkModeApp.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Follow night light.
+        /// </summary>
+        public static string cmbAlwBluelight {
+            get {
+                return ResourceManager.GetString("cmbAlwBluelight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always dark.
         /// </summary>
         public static string cmbAlwDark {
@@ -911,6 +920,15 @@ namespace AutoDarkModeApp.Properties {
         public static string or {
             get {
                 return ResourceManager.GetString("or", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Detect blue light filter.
+        /// </summary>
+        public static string rbBluelight {
+            get {
+                return ResourceManager.GetString("rbBluelight", resourceCulture);
             }
         }
         

--- a/AutoDarkModeApp/Properties/Resources.resx
+++ b/AutoDarkModeApp/Properties/Resources.resx
@@ -132,6 +132,9 @@
   <data name="cmbAlwWhite" xml:space="preserve">
     <value>Always light</value>
   </data>
+  <data name="cmbAlwBluelight" xml:space="preserve">
+    <value>Follow night light</value>
+  </data>
   <data name="debugModeCheckBox" xml:space="preserve">
     <value>Enable features for Windows 1903</value>
   </data>
@@ -423,6 +426,9 @@ You can set them up individually in your Windows Theme.</value>
   </data>
   <data name="rbLocation" xml:space="preserve">
     <value>From sunset to sunrise</value>
+  </data>
+  <data name="rbBluelight" xml:space="preserve">
+    <value>Detect blue light filter</value>
   </data>
   <data name="ThemeTutorialStep" xml:space="preserve">
     <value>Step</value>

--- a/AutoDarkModeApp/Properties/Settings.Designer.cs
+++ b/AutoDarkModeApp/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AutoDarkModeApp.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -146,6 +146,18 @@ namespace AutoDarkModeApp.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool WallpaperBluelight {
+            get {
+                return ((bool)(this["WallpaperBluelight"]));
+            }
+            set {
+                this["WallpaperBluelight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AlterTime {
             get {
                 return ((bool)(this["AlterTime"]));
@@ -260,6 +272,18 @@ namespace AutoDarkModeApp.Properties {
             }
             set {
                 this["ThemeSwitch"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ThemeBluelight {
+            get {
+                return ((bool)(this["ThemeBluelight"]));
+            }
+            set {
+                this["ThemeBluelight"] = value;
             }
         }
         
@@ -380,18 +404,6 @@ namespace AutoDarkModeApp.Properties {
             }
             set {
                 this["UIScale"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool DetectBlueLightFilter {
-            get {
-                return ((bool)(this["DetectBlueLightFilter"]));
-            }
-            set {
-                this["DetectBlueLightFilter"] = value;
             }
         }
     }

--- a/AutoDarkModeApp/Properties/Settings.Designer.cs
+++ b/AutoDarkModeApp/Properties/Settings.Designer.cs
@@ -382,5 +382,17 @@ namespace AutoDarkModeApp.Properties {
                 this["UIScale"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DetectBlueLightFilter {
+            get {
+                return ((bool)(this["DetectBlueLightFilter"]));
+            }
+            set {
+                this["DetectBlueLightFilter"] = value;
+            }
+        }
     }
 }

--- a/AutoDarkModeApp/Properties/Settings.settings
+++ b/AutoDarkModeApp/Properties/Settings.settings
@@ -92,5 +92,8 @@
     <Setting Name="UIScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
+    <Setting Name="DetectBlueLightFilter" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AutoDarkModeApp/Properties/Settings.settings
+++ b/AutoDarkModeApp/Properties/Settings.settings
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="AutoDarkModeApp.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
@@ -32,6 +32,9 @@
     <Setting Name="WallpaperSwitch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="WallpaperBluelight" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="AlterTime" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
@@ -60,6 +63,9 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ThemeSwitch" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ThemeBluelight" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="AccentColorSwitchTime" Type="System.Int32" Scope="User">
@@ -92,8 +98,6 @@
     <Setting Name="UIScale" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
-    <Setting Name="DetectBlueLightFilter" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
   </Settings>
 </SettingsFile>
+

--- a/AutoDarkModeSvc/Communication/MessageParser.cs
+++ b/AutoDarkModeSvc/Communication/MessageParser.cs
@@ -27,7 +27,10 @@ namespace AutoDarkModeSvc.Communication
                 {
                     case Command.Switch:
                         Logger.Info("signal received: time based theme switch");
-                        ThemeManager.TimedSwitch(builder);
+                        if(builder.BlueLightSwitchingEnabled)
+                            ThemeManager.BlueLightSwitch(builder);
+                        else
+                            ThemeManager.TimedSwitch(builder);
                         SendResponse(Response.Ok);
                         break;
 
@@ -158,7 +161,10 @@ namespace AutoDarkModeSvc.Communication
                     case Command.NoForce:
                         Logger.Info("signal received: resetting forced modes");
                         state.ForcedTheme = Theme.Undefined;
-                        ThemeManager.TimedSwitch(builder);
+                        if(builder.BlueLightSwitchingEnabled)
+                            ThemeManager.BlueLightSwitch(builder);
+                        else
+                            ThemeManager.TimedSwitch(builder);
                         SendResponse(Response.Ok);
                         break;
 

--- a/AutoDarkModeSvc/Communication/MessageParser.cs
+++ b/AutoDarkModeSvc/Communication/MessageParser.cs
@@ -27,7 +27,7 @@ namespace AutoDarkModeSvc.Communication
                 {
                     case Command.Switch:
                         Logger.Info("signal received: time based theme switch");
-                        if(builder.BlueLightSwitchingEnabled)
+                        if(builder.Config.BlueLightSwitchingEnabled)
                             ThemeManager.BlueLightSwitch(builder);
                         else
                             ThemeManager.TimedSwitch(builder);
@@ -161,7 +161,7 @@ namespace AutoDarkModeSvc.Communication
                     case Command.NoForce:
                         Logger.Info("signal received: resetting forced modes");
                         state.ForcedTheme = Theme.Undefined;
-                        if(builder.BlueLightSwitchingEnabled)
+                        if(builder.Config.BlueLightSwitchingEnabled)
                             ThemeManager.BlueLightSwitch(builder);
                         else
                             ThemeManager.TimedSwitch(builder);

--- a/AutoDarkModeSvc/Config/AdmConfig.cs
+++ b/AutoDarkModeSvc/Config/AdmConfig.cs
@@ -18,10 +18,11 @@ namespace AutoDarkModeSvc.Config
         private Mode appsTheme;
         private Mode systemTheme;
 
-        public bool AutoThemeSwitchingEnabled { get; set; }
+        public bool AutoThemeSwitchingEnabled { get; set; } = true;
         public bool ClassicMode { get; set; } = true;
         public bool ColorFilterEnabled { get; set; } = false;
-        public bool BlueLightSwitchingEnabled { get; set; }
+        public bool BlueLightSwitchingEnabled { get; set; } = false;
+        public bool TimeSwitchingEnabled { get; set; } = false;
         public bool AccentColorTaskbarEnabled { get; set; }
         public string DarkThemePath { get; set; }
         public string LightThemePath { get; set; }
@@ -32,7 +33,7 @@ namespace AutoDarkModeSvc.Config
             get { return appsTheme; }
             set
             {
-                if (value >= 0 && (int)value <= 2)
+                if (value >= 0 && (int)value <= 3)
                 {
                     appsTheme = value;
                 }
@@ -48,14 +49,14 @@ namespace AutoDarkModeSvc.Config
             get { return systemTheme; }
             set
             {
-                if (value >= 0 && (int)value <= 2)
+                if (value >= 0 && (int)value <= 3)
                 {
                     systemTheme = value;
                 }
                 else
                 {
                     // DEFAULT
-                    systemTheme = 0;
+                    systemTheme = Mode.Switch;
                 }
             }
         }

--- a/AutoDarkModeSvc/Config/AdmConfig.cs
+++ b/AutoDarkModeSvc/Config/AdmConfig.cs
@@ -21,6 +21,7 @@ namespace AutoDarkModeSvc.Config
         public bool AutoThemeSwitchingEnabled { get; set; }
         public bool ClassicMode { get; set; } = true;
         public bool ColorFilterEnabled { get; set; } = false;
+        public bool BlueLightSwitchingEnabled { get; set; }
         public bool AccentColorTaskbarEnabled { get; set; }
         public string DarkThemePath { get; set; }
         public string LightThemePath { get; set; }

--- a/AutoDarkModeSvc/Config/GlobalState.cs
+++ b/AutoDarkModeSvc/Config/GlobalState.cs
@@ -23,7 +23,7 @@ namespace AutoDarkModeSvc.Config
         {
             CurrentAppsTheme = RegistryHandler.AppsUseLightTheme() ? Theme.Light : Theme.Dark;
             CurrentSystemTheme = RegistryHandler.SystemUsesLightTheme() ? Theme.Light : Theme.Dark;
-            BlueLightSwitchingEnabled = RegistryHandler.IsNightLightEnabled();
+            CurrentBluelight = RegistryHandler.GetBluelightEnabled();
             CurrentColorPrevalence = RegistryHandler.IsColorPrevalence();
             CurrentWallpaperTheme = Theme.Undefined;
             CurrentWindowsThemeName = ThemeHandler.GetCurrentThemeName();
@@ -38,7 +38,7 @@ namespace AutoDarkModeSvc.Config
         public Theme CurrentWallpaperTheme { get; set; }
         public Theme CurrentOfficeTheme { get; set; }
         public bool ColorFilterEnabled { get; set; }
-        public bool BlueLightSwitchingEnabled { get; set; }
+        public bool CurrentBluelight { get; set; }
         public bool CurrentColorPrevalence { get; set; }
         public Theme ForcedTheme { get; set; }
         public string CurrentWindowsThemeName { get; set; }

--- a/AutoDarkModeSvc/Config/GlobalState.cs
+++ b/AutoDarkModeSvc/Config/GlobalState.cs
@@ -23,6 +23,7 @@ namespace AutoDarkModeSvc.Config
         {
             CurrentAppsTheme = RegistryHandler.AppsUseLightTheme() ? Theme.Light : Theme.Dark;
             CurrentSystemTheme = RegistryHandler.SystemUsesLightTheme() ? Theme.Light : Theme.Dark;
+            BlueLightSwitchingEnabled = RegistryHandler.IsNightLightEnabled();
             CurrentColorPrevalence = RegistryHandler.IsColorPrevalence();
             CurrentWallpaperTheme = Theme.Undefined;
             CurrentWindowsThemeName = ThemeHandler.GetCurrentThemeName();
@@ -37,6 +38,7 @@ namespace AutoDarkModeSvc.Config
         public Theme CurrentWallpaperTheme { get; set; }
         public Theme CurrentOfficeTheme { get; set; }
         public bool ColorFilterEnabled { get; set; }
+        public bool BlueLightSwitchingEnabled { get; set; }
         public bool CurrentColorPrevalence { get; set; }
         public Theme ForcedTheme { get; set; }
         public string CurrentWindowsThemeName { get; set; }

--- a/AutoDarkModeSvc/Extensions.cs
+++ b/AutoDarkModeSvc/Extensions.cs
@@ -8,7 +8,8 @@ namespace AutoDarkModeSvc
     {
         Switch = 0,
         LightOnly = 1,
-        DarkOnly = 2
+        DarkOnly = 2,
+        Bluelight = 3
     };
     public enum Theme
     {

--- a/AutoDarkModeSvc/Handlers/PowerEventHandler.cs
+++ b/AutoDarkModeSvc/Handlers/PowerEventHandler.cs
@@ -25,7 +25,7 @@ namespace AutoDarkModeSvc.Handlers
             }
             else
             {
-                if(builder.BlueLightSwitchingEnabled)
+                if(builder.Config.BlueLightSwitchingEnabled)
                     ThemeManager.BlueLightSwitch(builder);
                 else
                     ThemeManager.TimedSwitch(builder);
@@ -38,7 +38,7 @@ namespace AutoDarkModeSvc.Handlers
             {
                 PowerManager.BatteryStatusChanged -= PowerManager_BatteryStatusChanged;
                 AdmConfigBuilder builder = AdmConfigBuilder.Instance();
-                if(builder.BlueLightSwitchingEnabled)
+                if(builder.Config.BlueLightSwitchingEnabled)
                     ThemeManager.BlueLightSwitch(builder);
                 else
                     ThemeManager.TimedSwitch(builder);
@@ -60,7 +60,7 @@ namespace AutoDarkModeSvc.Handlers
             {
                 Logger.Info("system resuming from suspended state, refreshing theme");
                 AdmConfigBuilder builder = AdmConfigBuilder.Instance();
-                if(builder.BlueLightSwitchingEnabled)
+                if(builder.Config.BlueLightSwitchingEnabled)
                     ThemeManager.BlueLightSwitch(builder);
                 else
                     ThemeManager.TimedSwitch(builder);

--- a/AutoDarkModeSvc/Handlers/PowerEventHandler.cs
+++ b/AutoDarkModeSvc/Handlers/PowerEventHandler.cs
@@ -25,7 +25,10 @@ namespace AutoDarkModeSvc.Handlers
             }
             else
             {
-                ThemeManager.TimedSwitch(builder);
+                if(builder.BlueLightSwitchingEnabled)
+                    ThemeManager.BlueLightSwitch(builder);
+                else
+                    ThemeManager.TimedSwitch(builder);
             }
         }
 
@@ -34,7 +37,11 @@ namespace AutoDarkModeSvc.Handlers
             try
             {
                 PowerManager.BatteryStatusChanged -= PowerManager_BatteryStatusChanged;
-                ThemeManager.TimedSwitch(AdmConfigBuilder.Instance());
+                AdmConfigBuilder builder = AdmConfigBuilder.Instance();
+                if(builder.BlueLightSwitchingEnabled)
+                    ThemeManager.BlueLightSwitch(builder);
+                else
+                    ThemeManager.TimedSwitch(builder);
             }
             catch (InvalidOperationException ex)
             {
@@ -52,7 +59,11 @@ namespace AutoDarkModeSvc.Handlers
             if (e.Mode == PowerModes.Resume)
             {
                 Logger.Info("system resuming from suspended state, refreshing theme");
-                ThemeManager.TimedSwitch(AdmConfigBuilder.Instance());
+                AdmConfigBuilder builder = AdmConfigBuilder.Instance();
+                if(builder.BlueLightSwitchingEnabled)
+                    ThemeManager.BlueLightSwitch(builder);
+                else
+                    ThemeManager.TimedSwitch(builder);
             }
         }
 

--- a/AutoDarkModeSvc/Handlers/RegistryHandler.cs
+++ b/AutoDarkModeSvc/Handlers/RegistryHandler.cs
@@ -74,6 +74,23 @@ namespace AutoDarkModeSvc.Handlers
         }
 
         /// <summary>
+        /// Checks if the nightlight is enabled
+        /// </summary>
+        /// <returns>true if enabled; false otherwise</returns>
+        public static bool IsNightLightEnabled()
+        {
+            const string BlueLightReductionStateKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate";
+            using (var key = Registry.CurrentUser.OpenSubKey(BlueLightReductionStateKey))
+            {
+                var data = key?.GetValue("Data");
+                if (data is null)
+                    return false;
+                var byteData = (byte[])data;
+                return byteData.Length > 24 && byteData[23] == 0x10 && byteData[24] == 0x00;
+            }
+        }
+
+        /// <summary>
         /// Retrieves the operating system version
         /// </summary>
         /// <returns>operating system version string</returns>

--- a/AutoDarkModeSvc/Handlers/RegistryHandler.cs
+++ b/AutoDarkModeSvc/Handlers/RegistryHandler.cs
@@ -74,20 +74,16 @@ namespace AutoDarkModeSvc.Handlers
         }
 
         /// <summary>
-        /// Checks if the nightlight is enabled
+        /// Checks if the bluelight is enabled
         /// </summary>
         /// <returns>true if enabled; false otherwise</returns>
-        public static bool IsNightLightEnabled()
+        public static bool GetBluelightEnabled()
         {
-            const string BlueLightReductionStateKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate";
-            using (var key = Registry.CurrentUser.OpenSubKey(BlueLightReductionStateKey))
-            {
-                var data = key?.GetValue("Data");
-                if (data is null)
-                    return false;
-                var byteData = (byte[])data;
-                return byteData.Length > 24 && byteData[23] == 0x10 && byteData[24] == 0x00;
-            }
+            var data = GetBluelightKey();
+            if (data is null)
+                return false;
+            var byteData = (byte[])data;
+            return byteData.Length > 24 && byteData[23] == Decimal.ToByte(0x10) && byteData[24] == Decimal.ToByte(0x00);
         }
 
         /// <summary>
@@ -108,6 +104,16 @@ namespace AutoDarkModeSvc.Handlers
         {
             RegistryKey registryKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", true);
             return registryKey;
+        }
+
+        /// <summary>
+        /// Gets the current user's bluelight registry key value
+        /// </summary>
+        /// <returns>HKCU bluelight RegistryKey value</returns>
+        private static object GetBluelightKey()
+        {
+            var data = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate").GetValue("Data");
+            return data;
         }
 
         /// <summary>

--- a/AutoDarkModeSvc/Modules/BlueLightSwitchModule.cs
+++ b/AutoDarkModeSvc/Modules/BlueLightSwitchModule.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using AutoDarkModeSvc.Config;
+using System.Threading.Tasks;
+using AutoDarkModeSvc.Timers;
+using System.Diagnostics.CodeAnalysis;
+
+namespace AutoDarkModeSvc.Modules
+{
+    class BlueLightSwitchModule : AutoDarkModeModule
+    {
+        public override string TimerAffinity { get; } = TimerName.Main;
+        private AdmConfigBuilder ConfigBuilder { get; }
+
+        /// <summary>
+        /// Instantiates a new BlueLightSwitchModule.
+        /// This module switches themes based on blue light filter
+        /// </summary>
+        /// <param name="name">unique name of the module</param>
+        public BlueLightSwitchModule(string name, bool fireOnRegistration) : base(name, fireOnRegistration)
+        {
+            ConfigBuilder = AdmConfigBuilder.Instance();
+        }
+
+        public override void Fire()
+        {
+            Task.Run(() =>
+            {
+                ThemeManager.BlueLightSwitch(ConfigBuilder);
+            });
+        }
+    }
+}

--- a/AutoDarkModeSvc/Modules/BlueLightSwitchModule.cs
+++ b/AutoDarkModeSvc/Modules/BlueLightSwitchModule.cs
@@ -3,6 +3,7 @@ using AutoDarkModeSvc.Config;
 using System.Threading.Tasks;
 using AutoDarkModeSvc.Timers;
 using System.Diagnostics.CodeAnalysis;
+using AutoDarkModeSvc.Handlers;
 
 namespace AutoDarkModeSvc.Modules
 {
@@ -25,6 +26,7 @@ namespace AutoDarkModeSvc.Modules
         {
             Task.Run(() =>
             {
+                GlobalState.Instance().CurrentBluelight = RegistryHandler.GetBluelightEnabled();
                 ThemeManager.BlueLightSwitch(ConfigBuilder);
             });
         }

--- a/AutoDarkModeSvc/Modules/WardenModule.cs
+++ b/AutoDarkModeSvc/Modules/WardenModule.cs
@@ -33,6 +33,7 @@ namespace AutoDarkModeSvc.Modules
             AdmConfig config = ConfigBuilder.Config;
             AutoManageModule(typeof(GeopositionUpdateModule).Name, typeof(GeopositionUpdateModule), true, config.Location.Enabled);
             AutoManageModule(typeof(TimeSwitchModule).Name, typeof(TimeSwitchModule), true, config.AutoThemeSwitchingEnabled && !State.PostponeSwitch);
+            AutoManageModule(typeof(BlueLightSwitchModule).Name, typeof(BlueLightSwitchModule), true, config.BlueLightSwitchingEnabled && !State.PostponeSwitch);
             AutoManageModule(typeof(ThemeUpdateModule).Name, typeof(ThemeUpdateModule), true, !config.ClassicMode);
             AutoManageModule(typeof(GPUMonitorModuleV2).Name, typeof(GPUMonitorModuleV2), true, config.GPUMonitoring.Enabled);
             AutoManageModule(typeof(EventModule).Name, typeof(EventModule), true, config.Events.Enabled);

--- a/AutoDarkModeSvc/ThemeManager.cs
+++ b/AutoDarkModeSvc/ThemeManager.cs
@@ -16,18 +16,18 @@ namespace AutoDarkModeSvc
         public static void BlueLightSwitch(AdmConfigBuilder builder)
         {
             GlobalState state = GlobalState.Instance();
-            if (state.ForcedTheme == Theme.Dark) 
+            if (state.ForcedTheme == Theme.Dark)
             {
                 SwitchTheme(builder.Config, Theme.Dark);
                 return;
-            } 
-            else if (state.ForcedTheme == Theme.Light) 
+            }
+            else if (state.ForcedTheme == Theme.Light)
             {
                 SwitchTheme(builder.Config, Theme.Light);
                 return;
             }
 
-            if (builder.Config.BlueLightSwitchingEnabled)
+            if (!state.CurrentBluelight && builder.Config.SystemTheme == Mode.Bluelight)
             {
                 // ensure that the theme doesn't switch to light mode if the battery is discharging
                 if (builder.Config.Events.DarkThemeOnBattery && PowerManager.BatteryStatus != BatteryStatus.Discharging)
@@ -39,7 +39,7 @@ namespace AutoDarkModeSvc
                     SwitchTheme(builder.Config, Theme.Light, true);
                 }
             }
-            else
+            else if (state.CurrentBluelight && builder.Config.SystemTheme == Mode.Bluelight)
             {
                 SwitchTheme(builder.Config, Theme.Dark, true);
             }
@@ -48,12 +48,12 @@ namespace AutoDarkModeSvc
         public static void TimedSwitch(AdmConfigBuilder builder)
         {
             GlobalState state = GlobalState.Instance();
-            if (state.ForcedTheme == Theme.Dark) 
+            if (state.ForcedTheme == Theme.Dark)
             {
                 SwitchTheme(builder.Config, Theme.Dark);
                 return;
-            } 
-            else if (state.ForcedTheme == Theme.Light) 
+            }
+            else if (state.ForcedTheme == Theme.Light)
             {
                 SwitchTheme(builder.Config, Theme.Light);
                 return;
@@ -404,6 +404,13 @@ namespace AutoDarkModeSvc
                     return true;
                 }
             }
+            else if (config.SystemTheme == Mode.Bluelight)
+            {
+                if ((!config.AccentColorTaskbarEnabled && state.CurrentColorPrevalence) || config.AccentColorTaskbarEnabled && !state.CurrentColorPrevalence))
+                {
+                    return true;
+                }
+            }
             else if (config.SystemTheme == Mode.DarkOnly)
             {
                 if ((!config.AccentColorTaskbarEnabled && state.CurrentColorPrevalence) || (config.AccentColorTaskbarEnabled && !state.CurrentColorPrevalence))
@@ -445,8 +452,9 @@ namespace AutoDarkModeSvc
         {
             if ((componentMode == Mode.DarkOnly && currentComponentTheme != Theme.Dark)
                 || (componentMode == Mode.LightOnly && currentComponentTheme != Theme.Light)
-                || (componentMode == Mode.Switch && currentComponentTheme != newTheme)
-              )
+                || ((componentMode == Mode.Switch || componentMode == Mode.Bluelight) &&
+                    currentComponentTheme != newTheme)
+            )
             {
                 return true;
             }

--- a/AutoDarkModeSvc/ThemeManager.cs
+++ b/AutoDarkModeSvc/ThemeManager.cs
@@ -13,6 +13,38 @@ namespace AutoDarkModeSvc
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
+        public static void BlueLightSwitch(AdmConfigBuilder builder)
+        {
+            GlobalState state = GlobalState.Instance();
+            if (state.ForcedTheme == Theme.Dark) 
+            {
+                SwitchTheme(builder.Config, Theme.Dark);
+                return;
+            } 
+            else if (state.ForcedTheme == Theme.Light) 
+            {
+                SwitchTheme(builder.Config, Theme.Light);
+                return;
+            }
+
+            if (builder.Config.BlueLightSwitchingEnabled)
+            {
+                // ensure that the theme doesn't switch to light mode if the battery is discharging
+                if (builder.Config.Events.DarkThemeOnBattery && PowerManager.BatteryStatus != BatteryStatus.Discharging)
+                {
+                    SwitchTheme(builder.Config, Theme.Light, true);
+                }
+                else if (!builder.Config.Events.DarkThemeOnBattery)
+                {
+                    SwitchTheme(builder.Config, Theme.Light, true);
+                }
+            }
+            else
+            {
+                SwitchTheme(builder.Config, Theme.Dark, true);
+            }
+        }
+
         public static void TimedSwitch(AdmConfigBuilder builder)
         {
             GlobalState state = GlobalState.Instance();


### PR DESCRIPTION
See: https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/issues/256

Theoretically, this works fine. But the issues mentioned in https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/issues/256#issuecomment-916678841 did indeed apply. The time based module still seems to run and it keeps reverting the theme, but i am not sure if that might be caused by the service of the original program still running on my PC, i could not properly debug it yet.

A registryobserver would be a better implementation, currently it is getting changed the same way the timed mode detects it - using a task.

I am still opening this PR so it can be integrated in the future, but with better implementation