### PR TITLE
Fix UI bug with Windows default location

### DIFF
--- a/AutoDarkModeApp/Pages/PageTime.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageTime.xaml.cs
@@ -333,12 +333,12 @@ namespace AutoDarkModeApp.Pages
             {
                 ApiResponse result = ApiResponse.FromString(await messagingClient.SendMessageAndGetReplyAsync(Command.LocationAccess));
                 LocationHandler handler = new();
-                if (result.StatusCode == StatusCode.NoLocAccess && builder.Config.Location.UseGeolocatorService)
+                if (builder.Config.Location.UseGeolocatorService && result.StatusCode == StatusCode.NoLocAccess)
                 {
                     NoLocationAccess();
                     return;
                 }
-                else if (builder.Config.Location.UseGeolocatorService && (Geolocator.DefaultGeoposition.HasValue || result.StatusCode == StatusCode.Ok))
+                else if (builder.Config.Location.UseGeolocatorService && result.StatusCode == StatusCode.Ok)
                 {
                     locationBlock.Text = Properties.Resources.lblCity + ": " + await handler.GetCityName();
                 }

--- a/AutoDarkModeSvc/Communication/MessageParser.cs
+++ b/AutoDarkModeSvc/Communication/MessageParser.cs
@@ -128,7 +128,7 @@ namespace AutoDarkModeSvc.Communication
                     #region LocationAccess
                     case Command.LocationAccess:
                         Logger.Info("signal received: checking location access permissions");
-                        Task<bool> geoTask = Task.Run(async () => await LocationHandler.HasPermission());
+                        Task<bool> geoTask = Task.Run(async () => await LocationHandler.HasLocation());
                         geoTask.Wait();
                         var result = geoTask.Result;
                         if (result)

--- a/AutoDarkModeSvc/Handlers/LocationHandler.cs
+++ b/AutoDarkModeSvc/Handlers/LocationHandler.cs
@@ -117,9 +117,9 @@ namespace AutoDarkModeSvc.Handlers
 
         }
 
-        public async static Task<bool> HasPermission()
+        public async static Task<bool> HasLocation()
         {
-            return await Geolocator.RequestAccessAsync() == GeolocationAccessStatus.Allowed;
+            return await Geolocator.RequestAccessAsync() == GeolocationAccessStatus.Allowed || Geolocator.DefaultGeoposition.HasValue;
         }
 
         /// <summary>


### PR DESCRIPTION
Bug with feature #191 in new UI

If a user has Windows default location, it opens settings and asks to turn location on anyway. It still works though, but UI doesn't show it. To fix it, you can just change a method a little to return true not only if the location is on but also if there is a default