### PR TITLE
use other spelling in German translation

### DIFF
--- a/AutoDarkModeApp/Properties/Resources.de.resx
+++ b/AutoDarkModeApp/Properties/Resources.de.resx
@@ -554,7 +554,7 @@ Wir legen dieses Update jedem ans Herzen, außer ARM-Gerätebesitzer. Da Hinterg
     <value>Konfig</value>
   </data>
   <data name="headerGeoCoordinates" xml:space="preserve">
-    <value>Geographische Koordinaten</value>
+    <value>Geografische Koordinaten</value>
   </data>
   <data name="headerLocationData" xml:space="preserve">
     <value>Positionsdaten</value>
@@ -569,7 +569,7 @@ Wir legen dieses Update jedem ans Herzen, außer ARM-Gerätebesitzer. Da Hinterg
     <value>Deaktiviert</value>
   </data>
   <data name="rbLocationGeo" xml:space="preserve">
-    <value>Von Sonnenuntergang bis Sonnenaufgang (geographische Koordinaten)</value>
+    <value>Von Sonnenuntergang bis Sonnenaufgang (geografische Koordinaten)</value>
   </data>
   <data name="tbFeatureDisabledWhileThemeMode" xml:space="preserve">
     <value>Diese Funktion ist deaktiviert während der Windows Theme Modus aktiv ist</value>


### PR DESCRIPTION
I would rather use "geografisch" instead of "geographisch" in the German translation as it's more modern and [recommended by the Duden](https://de.wikipedia.org/wiki/Wikipedia:Rechtschreibung#ph_versus_f).