### PR TITLE
[Bugfix] Wrong wallpaper shown on single monitor mode

### DIFF
--- a/AutoDarkModeApp/Pages/PageWallpaperPicker.xaml.cs
+++ b/AutoDarkModeApp/Pages/PageWallpaperPicker.xaml.cs
@@ -352,6 +352,10 @@ namespace AutoDarkModeApp.Pages
 
         private void ComboBoxMonitorSelection_SelectionChanged(object sender, EventArgs e)
         {
+            //fixes bug that shows multi monitor wallpaper on single monitor mode
+            if (ComboBoxWallpaperTypeSelection.SelectedItem != ComboBoxBackgroundSelectionIndividual)
+                return;
+
             MonitorSettings monitorSettings = (MonitorSettings)ComboBoxMonitorSelection.SelectedItem;
             if (monitorSettings != null && SelectedLight)
             {


### PR DESCRIPTION
There was a bug that shows the wallpaper for multi monitor mode, even when having selected single monitor mode.

Video of before and after:
https://photos.google.com/share/AF1QipPOYb42AW-5FthubnjHzdk-TIst1Ub3UPuz1EO39t7grL6SrHa51a-JRdqZDWgYWw?key=X2xrYlktdzFUM0pvYmdVcFF0c3BWeWVsQWh5cFhR