### PR TITLE
Clarify geo coordinates action label

### DIFF
--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -532,7 +532,7 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
     <value>From sunset to sunrise (geographic coordinates)</value>
   </data>
   <data name="tbGetCoordinates" xml:space="preserve">
-    <value>Geo coordinates for your location</value>
+    <value>Find geo coordinates for your location</value>
   </data>
   <data name="ConfigHyperLinkOpenConfig" xml:space="preserve">
     <value>Open config file</value>


### PR DESCRIPTION
Current wording makes it appear as if it's just a help text explaining what to put into the lat/long fields.
But it's actually a helpful, clickable action that links to a very handy webpage.