### PR TITLE
Add access keys to tray menu

### DIFF
--- a/AutoDarkModeLib/Properties/Resources.Designer.cs
+++ b/AutoDarkModeLib/Properties/Resources.Designer.cs
@@ -2556,7 +2556,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pause auto switch.
+        ///   Looks up a localized string similar to &amp;Pause auto switch.
         /// </summary>
         public static string TrayMenuItemThemeSwitchPause {
             get {

--- a/AutoDarkModeLib/Properties/Resources.Designer.cs
+++ b/AutoDarkModeLib/Properties/Resources.Designer.cs
@@ -2520,7 +2520,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Automatic theme switch.
+        ///   Looks up a localized string similar to &amp;Automatic theme switch.
         /// </summary>
         public static string TrayMenuItemAutomaticThemeSwitch {
             get {
@@ -2529,7 +2529,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Close.
+        ///   Looks up a localized string similar to &amp;Close.
         /// </summary>
         public static string TrayMenuItemClose {
             get {
@@ -2538,7 +2538,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force Dark Theme.
+        ///   Looks up a localized string similar to Force &amp;Dark Theme.
         /// </summary>
         public static string TrayMenuItemForceDarkTheme {
             get {
@@ -2547,7 +2547,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force Light Theme.
+        ///   Looks up a localized string similar to Force &amp;Light Theme.
         /// </summary>
         public static string TrayMenuItemForceLightTheme {
             get {
@@ -2556,7 +2556,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Config Directory.
+        ///   Looks up a localized string similar to &amp;Open Config Directory.
         /// </summary>
         public static string TrayMenuItemOpenConfigDir {
             get {
@@ -2565,7 +2565,7 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Toggle theme.
+        ///   Looks up a localized string similar to &amp;Toggle theme.
         /// </summary>
         public static string TrayMenuItemToggleTheme {
             get {

--- a/AutoDarkModeLib/Properties/Resources.Designer.cs
+++ b/AutoDarkModeLib/Properties/Resources.Designer.cs
@@ -2195,15 +2195,6 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pause auto switch.
-        /// </summary>
-        public static string ThemeSwitchPause {
-            get {
-                return ResourceManager.GetString("ThemeSwitchPause", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Would you like to disable auto switching instead?.
         /// </summary>
         public static string ThemeSwitchPauseActionDisableQuestion {
@@ -2561,6 +2552,15 @@ namespace AutoDarkModeLib.Properties {
         public static string TrayMenuItemOpenConfigDir {
             get {
                 return ResourceManager.GetString("TrayMenuItemOpenConfigDir", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pause auto switch.
+        /// </summary>
+        public static string TrayMenuItemThemeSwitchPause {
+            get {
+                return ResourceManager.GetString("TrayMenuItemThemeSwitchPause", resourceCulture);
             }
         }
         

--- a/AutoDarkModeLib/Properties/Resources.Designer.cs
+++ b/AutoDarkModeLib/Properties/Resources.Designer.cs
@@ -641,24 +641,6 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force Dark Theme.
-        /// </summary>
-        public static string ForceDarkTheme {
-            get {
-                return ResourceManager.GetString("ForceDarkTheme", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Force Light Theme.
-        /// </summary>
-        public static string ForceLightTheme {
-            get {
-                return ResourceManager.GetString("ForceLightTheme", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Geographic coordinates.
         /// </summary>
         public static string headerGeoCoordinates {
@@ -2534,6 +2516,24 @@ namespace AutoDarkModeLib.Properties {
         public static string ToolTipOfficeDisclaimer {
             get {
                 return ResourceManager.GetString("ToolTipOfficeDisclaimer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force Dark Theme.
+        /// </summary>
+        public static string TrayMenuItemForceDarkTheme {
+            get {
+                return ResourceManager.GetString("TrayMenuItemForceDarkTheme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force Light Theme.
+        /// </summary>
+        public static string TrayMenuItemForceLightTheme {
+            get {
+                return ResourceManager.GetString("TrayMenuItemForceLightTheme", resourceCulture);
             }
         }
         

--- a/AutoDarkModeLib/Properties/Resources.Designer.cs
+++ b/AutoDarkModeLib/Properties/Resources.Designer.cs
@@ -2520,6 +2520,24 @@ namespace AutoDarkModeLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Automatic theme switch.
+        /// </summary>
+        public static string TrayMenuItemAutomaticThemeSwitch {
+            get {
+                return ResourceManager.GetString("TrayMenuItemAutomaticThemeSwitch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        public static string TrayMenuItemClose {
+            get {
+                return ResourceManager.GetString("TrayMenuItemClose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Force Dark Theme.
         /// </summary>
         public static string TrayMenuItemForceDarkTheme {
@@ -2543,6 +2561,15 @@ namespace AutoDarkModeLib.Properties {
         public static string TrayMenuItemOpenConfigDir {
             get {
                 return ResourceManager.GetString("TrayMenuItemOpenConfigDir", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle theme.
+        /// </summary>
+        public static string TrayMenuItemToggleTheme {
+            get {
+                return ResourceManager.GetString("TrayMenuItemToggleTheme", resourceCulture);
             }
         }
         

--- a/AutoDarkModeLib/Properties/Resources.cs.resx
+++ b/AutoDarkModeLib/Properties/Resources.cs.resx
@@ -820,10 +820,10 @@ Prosím NIKDY nespouštějte Auto Dark Mode coby administrátor!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.cs.resx
+++ b/AutoDarkModeLib/Properties/Resources.cs.resx
@@ -890,7 +890,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.cs.resx
+++ b/AutoDarkModeLib/Properties/Resources.cs.resx
@@ -1120,4 +1120,13 @@ Do you really want to continue?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Image path</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Zavřít</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.de.resx
+++ b/AutoDarkModeLib/Properties/Resources.de.resx
@@ -821,10 +821,10 @@ Hinweis: bitte starte Auto Dark Mode niemals manuell als Administrator!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Tastatur-Hotkeys aktivieren</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Erzwinge dunkles Design</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Erzwinge helles Design</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.de.resx
+++ b/AutoDarkModeLib/Properties/Resources.de.resx
@@ -1121,4 +1121,13 @@ Möchten Sie wirklich fortfahren?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Dateipfad</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatischer Designwechsel</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Design umschalten</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.de.resx
+++ b/AutoDarkModeLib/Properties/Resources.de.resx
@@ -891,7 +891,7 @@ Möchten Sie wirklich fortfahren?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Rückgängig</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Auto-Wechsel pausieren</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.el-gr.resx
+++ b/AutoDarkModeLib/Properties/Resources.el-gr.resx
@@ -821,10 +821,10 @@
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Ενεργοποίηση πλήκτρων συντόμευσης σε όλο το σύστημα</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Επιβολή Σκοτεινής Λειτουργίας</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Επιβολή Φωτεινής Λειτουργίας</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.el-gr.resx
+++ b/AutoDarkModeLib/Properties/Resources.el-gr.resx
@@ -891,7 +891,7 @@
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Αναίρεση</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Παύση αυτόματης εναλλαγής</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.el-gr.resx
+++ b/AutoDarkModeLib/Properties/Resources.el-gr.resx
@@ -1121,4 +1121,13 @@
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Διαδρομή εικόνας</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Κλείσιμο</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Αυτόματη εναλλαγή θεματος</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Ενεργοποίηση/απενεργοποίηση θέματος</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.es.resx
+++ b/AutoDarkModeLib/Properties/Resources.es.resx
@@ -891,7 +891,7 @@ Por cierto, ¡NUNCA ejecutes Auto Dark Mode como administrador manualmente!</val
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Deshacer</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pausar cambio automático</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.es.resx
+++ b/AutoDarkModeLib/Properties/Resources.es.resx
@@ -821,10 +821,10 @@ Por cierto, ¡NUNCA ejecutes Auto Dark Mode como administrador manualmente!</val
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Activar atajos de teclado a nivel de sistema</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forzar el tema oscuro</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forzar el tema claro</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.es.resx
+++ b/AutoDarkModeLib/Properties/Resources.es.resx
@@ -1121,4 +1121,13 @@ Por cierto, ¡NUNCA ejecutes Auto Dark Mode como administrador manualmente!</val
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Ruta de imagen</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Cambio de tema automático</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Cambiar tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.fr.resx
+++ b/AutoDarkModeLib/Properties/Resources.fr.resx
@@ -821,10 +821,10 @@ Remarque : N'exécutez JAMAIS Auto Dark Mode en tant qu'administrateur manuellem
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Activer les raccourcis du système</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forcer le thème sombre</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forcer le thème clair</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.fr.resx
+++ b/AutoDarkModeLib/Properties/Resources.fr.resx
@@ -891,7 +891,7 @@ Voulez-vous vraiment continuer ?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Annuler</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Suspendre le changement automatique</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.fr.resx
+++ b/AutoDarkModeLib/Properties/Resources.fr.resx
@@ -1121,4 +1121,13 @@ Voulez-vous vraiment continuer ?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Emplacement de l'image</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Basculement automatique du thème</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Basculer de thème</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.he.resx
+++ b/AutoDarkModeLib/Properties/Resources.he.resx
@@ -891,7 +891,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.he.resx
+++ b/AutoDarkModeLib/Properties/Resources.he.resx
@@ -1121,4 +1121,13 @@ Do you really want to continue?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Image path</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.he.resx
+++ b/AutoDarkModeLib/Properties/Resources.he.resx
@@ -821,10 +821,10 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.hu.resx
+++ b/AutoDarkModeLib/Properties/Resources.hu.resx
@@ -1121,4 +1121,13 @@ Tényleg folytatni szeretné?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Kép elérési útja</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Bezárás</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatikus témaváltás</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Téma váltása</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.hu.resx
+++ b/AutoDarkModeLib/Properties/Resources.hu.resx
@@ -891,7 +891,7 @@ Tényleg folytatni szeretné?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Visszavonás</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Az automatikus váltás szüneteltetése</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.hu.resx
+++ b/AutoDarkModeLib/Properties/Resources.hu.resx
@@ -821,10 +821,10 @@ Mellékjegyzet: SOHA ne futtassa manuálisan rendszergazdaként az Auto Dark Mod
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Rendszerszintű gyorsbillentyűk engedélyezése</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Sötét téma kényszerítése</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Világos téma kényszerítése</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.id.resx
+++ b/AutoDarkModeLib/Properties/Resources.id.resx
@@ -821,10 +821,10 @@ Pesan: tolong untuk TIDAK menjalankan Auto Dark Mode dengan Administrator!</valu
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Nyalakan hotkey secara system-wide</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Paksa Mode Gelap</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Paksa Mode Terang</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.id.resx
+++ b/AutoDarkModeLib/Properties/Resources.id.resx
@@ -1121,4 +1121,13 @@ Pesan: tolong untuk TIDAK menjalankan Auto Dark Mode dengan Administrator!</valu
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Alamat gambar</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Tutup</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Pergantian tema otomatis</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Beralih tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.id.resx
+++ b/AutoDarkModeLib/Properties/Resources.id.resx
@@ -891,7 +891,7 @@ Pesan: tolong untuk TIDAK menjalankan Auto Dark Mode dengan Administrator!</valu
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Batalkan</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Tunda pergantian otomatis</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.it.resx
+++ b/AutoDarkModeLib/Properties/Resources.it.resx
@@ -1121,4 +1121,13 @@ Vuoi davvero continuare?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Percorso immagine</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Cambio automatico del tema</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Gestisci tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.it.resx
+++ b/AutoDarkModeLib/Properties/Resources.it.resx
@@ -891,7 +891,7 @@ Vuoi davvero continuare?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Ripristina</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Metti in pausa del cambio automatico</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.it.resx
+++ b/AutoDarkModeLib/Properties/Resources.it.resx
@@ -821,10 +821,10 @@ PS: non avviare MAI Auto Dark Mode come amministratore!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Abilita le scorciatoie a livello di sistema</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forza Tema Scuro</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forza Tema Chiaro</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ja.resx
+++ b/AutoDarkModeLib/Properties/Resources.ja.resx
@@ -891,7 +891,7 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>元に戻す</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>自動切替を停止</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ja.resx
+++ b/AutoDarkModeLib/Properties/Resources.ja.resx
@@ -1121,4 +1121,13 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>画像のパス</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>テーマの自動切替</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>テーマを切り替える</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.ja.resx
+++ b/AutoDarkModeLib/Properties/Resources.ja.resx
@@ -821,10 +821,10 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>システム全体でホットキーを有効にする</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>ダークテーマに変更</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>ライトテーマに変更</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ko.resx
+++ b/AutoDarkModeLib/Properties/Resources.ko.resx
@@ -890,7 +890,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ko.resx
+++ b/AutoDarkModeLib/Properties/Resources.ko.resx
@@ -820,10 +820,10 @@ Click "Yes" to open a new browser window.
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ko.resx
+++ b/AutoDarkModeLib/Properties/Resources.ko.resx
@@ -1120,4 +1120,13 @@ Do you really want to continue?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Image path</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.nb-no.resx
+++ b/AutoDarkModeLib/Properties/Resources.nb-no.resx
@@ -490,10 +490,10 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.nb-no.resx
+++ b/AutoDarkModeLib/Properties/Resources.nb-no.resx
@@ -551,7 +551,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.nb-no.resx
+++ b/AutoDarkModeLib/Properties/Resources.nb-no.resx
@@ -1101,4 +1101,13 @@ Click "Yes" to open a new browser window.
   <data name="cbConnectedStandby" xml:space="preserve">
     <value>Switch after Connected Standby (not recommended)</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.nl.resx
+++ b/AutoDarkModeLib/Properties/Resources.nl.resx
@@ -821,10 +821,10 @@ N.B.: Voer Auto Dark Mode NOOIT handmatig uit als administrator!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Sneltoetsen in systeem inschakelen</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Donker thema forceren</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Licht thema forceren</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.nl.resx
+++ b/AutoDarkModeLib/Properties/Resources.nl.resx
@@ -1121,4 +1121,13 @@ N.B.: Voer Auto Dark Mode NOOIT handmatig uit als administrator!</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Image path</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatische thema wissel</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.nl.resx
+++ b/AutoDarkModeLib/Properties/Resources.nl.resx
@@ -891,7 +891,7 @@ N.B.: Voer Auto Dark Mode NOOIT handmatig uit als administrator!</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Ongedaan maken</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Automatisch wisselen pauzeren</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pl.resx
+++ b/AutoDarkModeLib/Properties/Resources.pl.resx
@@ -827,10 +827,10 @@ Jeśli będzie dostępna aktualizacja, otrzymasz powiadomienie.</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Włącz skróty klawiszowe</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Wymuś ciemny motyw</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Wymuś jasny motyw</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pl.resx
+++ b/AutoDarkModeLib/Properties/Resources.pl.resx
@@ -1127,4 +1127,13 @@ Czy chcesz kontynuować?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Ścieżka obrazu</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Zamknij</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatyczne przełączanie motywu</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Przełącz motyw</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.pl.resx
+++ b/AutoDarkModeLib/Properties/Resources.pl.resx
@@ -897,7 +897,7 @@ Czy chcesz kontynuować?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Cofnij</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Wstrzymaj automatyczne przełączanie</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pt-br.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-br.resx
@@ -821,10 +821,10 @@ Uma nota à parte: NUNCA corra o Auto Dark Mode como Administrador manualmente!<
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Activar as teclas de atalho por todo o sistema</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forçar o Tema Escuro</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forçar o Tema Claro</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pt-br.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-br.resx
@@ -891,7 +891,7 @@ Tem a certeza que quer continuar?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Anular</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pausar mudança automática</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pt-br.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-br.resx
@@ -1121,4 +1121,13 @@ Tem a certeza que quer continuar?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Caminho da imagem</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Mudança automática do tema</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Alternar tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.pt-pt.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-pt.resx
@@ -892,7 +892,7 @@ Tem a certeza que quer continuar?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Anular</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pausar mudança automática</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.pt-pt.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-pt.resx
@@ -1122,4 +1122,13 @@ Tem a certeza que quer continuar?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Caminho da imagem</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Mudança automática do tema</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Alternar tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.pt-pt.resx
+++ b/AutoDarkModeLib/Properties/Resources.pt-pt.resx
@@ -822,10 +822,10 @@ Uma nota à parte: NUNCA corra o Auto Dark Mode como Administrador manualmente!<
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Activar as teclas de atalho por todo o sistema</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forçar o Tema Escuro</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forçar o Tema Claro</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -897,7 +897,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -318,6 +318,9 @@ If you run into issues: please increase the switching delay in settings.</value>
   <data name="msgClose" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
   <data name="msgNo" xml:space="preserve">
     <value>No</value>
   </data>
@@ -855,6 +858,9 @@ Do you really want to continue?</value>
   <data name="AutomaticThemeSwitch" xml:space="preserve">
     <value>Automatic theme switch</value>
   </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
   <data name="HotkeyCheckboxToggleAutomaticThemeSwitchNotification" xml:space="preserve">
     <value>Show notification on toggle</value>
   </data>
@@ -913,6 +919,9 @@ Do you really want to continue?</value>
     <value>Postpone control</value>
   </data>
   <data name="ToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
     <value>Toggle theme</value>
   </data>
   <data name="TimePagePostponeInfoNominal" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -898,7 +898,7 @@ Do you really want to continue?</value>
     <value>Undo</value>
   </data>
   <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
-    <value>Pause auto switch</value>
+    <value>&amp;Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">
     <value>Would you like to disable auto switching instead?</value>

--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -821,10 +821,10 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.resx
+++ b/AutoDarkModeLib/Properties/Resources.resx
@@ -319,7 +319,7 @@ If you run into issues: please increase the switching delay in settings.</value>
     <value>Close</value>
   </data>
   <data name="TrayMenuItemClose" xml:space="preserve">
-    <value>Close</value>
+    <value>&amp;Close</value>
   </data>
   <data name="msgNo" xml:space="preserve">
     <value>No</value>
@@ -825,10 +825,10 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
     <value>Enable system-wide hotkeys</value>
   </data>
   <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
-    <value>Force Dark Theme</value>
+    <value>Force &amp;Dark Theme</value>
   </data>
   <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
-    <value>Force Light Theme</value>
+    <value>Force &amp;Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">
     <value>Hiding the icon isn't recommended.
@@ -838,7 +838,7 @@ Do you really want to continue?</value>
     <value>Hide Tray Icon</value>
   </data>
   <data name="TrayMenuItemOpenConfigDir" xml:space="preserve">
-    <value>Open Config Directory</value>
+    <value>&amp;Open Config Directory</value>
   </data>
   <data name="LabelFollowSystemTheme" xml:space="preserve">
     <value>Let the app decide</value>
@@ -859,7 +859,7 @@ Do you really want to continue?</value>
     <value>Automatic theme switch</value>
   </data>
   <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
-    <value>Automatic theme switch</value>
+    <value>&amp;Automatic theme switch</value>
   </data>
   <data name="HotkeyCheckboxToggleAutomaticThemeSwitchNotification" xml:space="preserve">
     <value>Show notification on toggle</value>
@@ -922,7 +922,7 @@ Do you really want to continue?</value>
     <value>Toggle theme</value>
   </data>
   <data name="TrayMenuItemToggleTheme" xml:space="preserve">
-    <value>Toggle theme</value>
+    <value>&amp;Toggle theme</value>
   </data>
   <data name="TimePagePostponeInfoNominal" xml:space="preserve">
     <value>Auto theme switching is enabled</value>

--- a/AutoDarkModeLib/Properties/Resources.ro.resx
+++ b/AutoDarkModeLib/Properties/Resources.ro.resx
@@ -1121,4 +1121,13 @@ Chiar vreți să continuați?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Calea imaginii</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Închideți</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Schimbare automată a temei</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Schimbă tema</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.ro.resx
+++ b/AutoDarkModeLib/Properties/Resources.ro.resx
@@ -821,10 +821,10 @@ Notă secundară: NU rulați NICIODATĂ Auto Dark Mode ca administrator manual!<
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Activați tastele rapide la nivel de sistem</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Forțați temă întunecată</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Forțați temă întunecată</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ro.resx
+++ b/AutoDarkModeLib/Properties/Resources.ro.resx
@@ -891,7 +891,7 @@ Chiar vreți să continuați?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Anulează</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Întrerupeți schimbarea automată</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ru.resx
+++ b/AutoDarkModeLib/Properties/Resources.ru.resx
@@ -891,7 +891,7 @@
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Отменить</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Приостановить автопереключение</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ru.resx
+++ b/AutoDarkModeLib/Properties/Resources.ru.resx
@@ -821,10 +821,10 @@
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Включить системные горячие клавиши</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Принудительно тёмная тема</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Принудительно светлая тема</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.ru.resx
+++ b/AutoDarkModeLib/Properties/Resources.ru.resx
@@ -1121,4 +1121,13 @@
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Путь к изображению</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Автоматическое переключение темы</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Переключить тему</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.sr.resx
+++ b/AutoDarkModeLib/Properties/Resources.sr.resx
@@ -1121,4 +1121,13 @@ Jeste li sigurni da želite da nastavite?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Putanja do slike</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Zatvori</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatska promena tema</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Promeni temu</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.sr.resx
+++ b/AutoDarkModeLib/Properties/Resources.sr.resx
@@ -891,7 +891,7 @@ Jeste li sigurni da želite da nastavite?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Opozovi</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pauziraj automatsku promenu</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.sr.resx
+++ b/AutoDarkModeLib/Properties/Resources.sr.resx
@@ -821,10 +821,10 @@ Napomena: NIKAD ne pokrećite Auto Dark Mode kao administrator sami!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Omogući tasterske prečice</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Prisili tamnu temu</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Prisili svetlu temu</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.sv.resx
+++ b/AutoDarkModeLib/Properties/Resources.sv.resx
@@ -891,7 +891,7 @@ Do you really want to continue?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Pause auto switch</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.sv.resx
+++ b/AutoDarkModeLib/Properties/Resources.sv.resx
@@ -1121,4 +1121,13 @@ Do you really want to continue?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Image path</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Automatic theme switch</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.sv.resx
+++ b/AutoDarkModeLib/Properties/Resources.sv.resx
@@ -821,10 +821,10 @@ Sidenote: NEVER run Auto Dark Mode as administrator manually!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Enable system-wide hotkeys</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Force Dark Theme</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Force Light Theme</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.tr.resx
+++ b/AutoDarkModeLib/Properties/Resources.tr.resx
@@ -891,7 +891,7 @@ Gerçekten devam etmek istiyor musunuz?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Geri al</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Otomatik değişimi duraklat</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.tr.resx
+++ b/AutoDarkModeLib/Properties/Resources.tr.resx
@@ -821,10 +821,10 @@ Not: Auto Dark Mode'u elle yönetici olarak ASLA çalıştırmayın!</value>
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Sistem genelinde kısayol tuşlarını etkinleştir</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Koyu temayı zorla</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Açık temayı zorla</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.tr.resx
+++ b/AutoDarkModeLib/Properties/Resources.tr.resx
@@ -1121,4 +1121,13 @@ Gerçekten devam etmek istiyor musunuz?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Resim konumu</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Çıkış</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Otomatik tema değişimi</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Temayı değiştir</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.uk.resx
+++ b/AutoDarkModeLib/Properties/Resources.uk.resx
@@ -1121,4 +1121,13 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Розташування зображення</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Автоматичне перемикання тем</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Перемкнути тему</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.uk.resx
+++ b/AutoDarkModeLib/Properties/Resources.uk.resx
@@ -891,7 +891,7 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Скасувати</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Призупинити автоперемикання</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.uk.resx
+++ b/AutoDarkModeLib/Properties/Resources.uk.resx
@@ -821,10 +821,10 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Дозволити загальносистемні гарячі клавіші</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Примусова темна тема</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Примусова світла тема</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.vi.resx
+++ b/AutoDarkModeLib/Properties/Resources.vi.resx
@@ -891,7 +891,7 @@ Bạn có muốn tiếp tục?</value>
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>Đảo ngược</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>Tạm dừng tự động chuyển</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.vi.resx
+++ b/AutoDarkModeLib/Properties/Resources.vi.resx
@@ -1121,4 +1121,13 @@ Bạn có muốn tiếp tục?</value>
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>Đường dẫn hình ảnh</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>Tắt</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>Tự động chuyển chủ đề</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>Bật tắt chủ đề</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.vi.resx
+++ b/AutoDarkModeLib/Properties/Resources.vi.resx
@@ -821,10 +821,10 @@ Lưu chú: KHÔNG BAO GIỜ chạy Chủ đề tối tự động với quyền 
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>Bật phím tắt cho toàn hệ thống</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>Cưỡng ép chủ đề tối</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>Cưỡng ép chủ đề sáng</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.zh-hans.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hans.resx
@@ -821,10 +821,10 @@ GitHub 上发布了新版本，修复了一些漏洞并增加了新功能。
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>启用系统级快捷键</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>强制深色主题</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>强制浅色主题</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.zh-hans.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hans.resx
@@ -1121,4 +1121,13 @@ GitHub 上发布了新版本，修复了一些漏洞并增加了新功能。
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>图片路径</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>自动切换主题</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>启用主题</value>
+  </data>
 </root>

--- a/AutoDarkModeLib/Properties/Resources.zh-hans.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hans.resx
@@ -891,7 +891,7 @@ GitHub 上发布了新版本，修复了一些漏洞并增加了新功能。
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>撤销</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>暂停自动切换</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.zh-hant.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hant.resx
@@ -891,7 +891,7 @@ Auto Dark Mode 將在之後自動重新啟動，但是您必須重新套用您�
   <data name="ThemeSwitchActionUndo" xml:space="preserve">
     <value>復原</value>
   </data>
-  <data name="ThemeSwitchPause" xml:space="preserve">
+  <data name="TrayMenuItemThemeSwitchPause" xml:space="preserve">
     <value>暫停自動切換</value>
   </data>
   <data name="ThemeSwitchPauseActionDisableQuestion" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.zh-hant.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hant.resx
@@ -821,10 +821,10 @@ Auto Dark Mode 將在之後自動重新啟動，但是您必須重新套用您�
   <data name="SwitchModesToggleHeaderHotkey" xml:space="preserve">
     <value>啟用全域快速鍵</value>
   </data>
-  <data name="ForceDarkTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceDarkTheme" xml:space="preserve">
     <value>強制使用深色模式</value>
   </data>
-  <data name="ForceLightTheme" xml:space="preserve">
+  <data name="TrayMenuItemForceLightTheme" xml:space="preserve">
     <value>強制使用淺色模式</value>
   </data>
   <data name="SettingsPageTrayDisableMessageBoxContent" xml:space="preserve">

--- a/AutoDarkModeLib/Properties/Resources.zh-hant.resx
+++ b/AutoDarkModeLib/Properties/Resources.zh-hant.resx
@@ -1121,4 +1121,13 @@ Auto Dark Mode 將在之後自動重新啟動，但是您必須重新套用您�
   <data name="WallpaperTextBlockImagePath" xml:space="preserve">
     <value>圖片路徑</value>
   </data>
+  <data name="TrayMenuItemClose" xml:space="preserve">
+    <value>關閉</value>
+  </data>
+  <data name="TrayMenuItemAutomaticThemeSwitch" xml:space="preserve">
+    <value>自動切換主題</value>
+  </data>
+  <data name="TrayMenuItemToggleTheme" xml:space="preserve">
+    <value>切換主題</value>
+  </data>
 </root>

--- a/AutoDarkModeSvc/Program.cs
+++ b/AutoDarkModeSvc/Program.cs
@@ -36,6 +36,12 @@ namespace AutoDarkModeSvc
         private static readonly Mutex mutex = new(false, "330f929b-ac7a-4791-9958-f8b9268ca35d");
         private static Service Service { get; set; }
 
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        private static extern int SystemParametersInfo(int uAction, int uParam, int lpvParam, int fuWinIni);
+
+        private const int SPI_SETKEYBOARDCUES = 4107; //100B
+        private const int SPIF_SENDWININICHANGE = 2;
+
         public static BlockingCollection<Action> ActionQueue = new();
         private static Thread queueThread;
 
@@ -239,6 +245,17 @@ namespace AutoDarkModeSvc
                 Application.SetCompatibleTextRenderingDefault(false);
                 Service = new Service(timerMillis);
                 Service.Text = "Auto Dark Mode";
+
+                try
+                {
+                    // always show accelerator underlines
+                    _ = SystemParametersInfo(SPI_SETKEYBOARDCUES, 0, 1, 0);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn(ex, "could not set access key highlight flag");
+                }
+
                 Application.Run(Service);
 
             }

--- a/AutoDarkModeSvc/Service.cs
+++ b/AutoDarkModeSvc/Service.cs
@@ -72,8 +72,8 @@ namespace AutoDarkModeSvc
             autoThemeSwitchingItem.Name = "autoThemeSwitching";
             toggleThemeItem.Name = "toggleTheme";
             pauseThemeSwitchItem.Name = "pauseThemeSwitch";
-            forceDarkMenuItem.Text = AdmProperties.Resources.ForceDarkTheme;
-            forceLightMenuItem.Text = AdmProperties.Resources.ForceLightTheme;
+            forceDarkMenuItem.Text = AdmProperties.Resources.TrayMenuItemForceDarkTheme;
+            forceLightMenuItem.Text = AdmProperties.Resources.TrayMenuItemForceLightTheme;
             autoThemeSwitchingItem.Text = AdmProperties.Resources.AutomaticThemeSwitch;
             toggleThemeItem.Text = AdmProperties.Resources.ToggleTheme;
 

--- a/AutoDarkModeSvc/Service.cs
+++ b/AutoDarkModeSvc/Service.cs
@@ -204,8 +204,8 @@ namespace AutoDarkModeSvc
             {
                 DateTime expiry = tempDelay.Expiry ?? new();
                 pauseThemeSwitchItem.Checked = true;
-                if (expiry.Day > DateTime.Now.Day) pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry.ToString("ddd HH:mm", new CultureInfo(Builder.Config.Tunable.UICulture))})";
-                else pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry:HH:mm})";
+                if (expiry.Day > DateTime.Now.Day) pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry.ToString("ddd HH:mm", new CultureInfo(Builder.Config.Tunable.UICulture))})";
+                else pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry:HH:mm})";
             }
             else
             {
@@ -213,22 +213,22 @@ namespace AutoDarkModeSvc
                 (DateTime expiry, SkipType skipType) = state.PostponeManager.GetSkipNextSwitchExpiryTime();
                 if (expiry.Year != 1)
                 {
-                    if (expiry.Day > DateTime.Now.Day) pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry.ToString("ddd HH:mm", new CultureInfo(Builder.Config.Tunable.UICulture))})";
-                    else pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry:HH:mm})";
+                    if (expiry.Day > DateTime.Now.Day) pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry.ToString("ddd HH:mm", new CultureInfo(Builder.Config.Tunable.UICulture))})";
+                    else pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.UntilTime} {expiry:HH:mm})";
                 }
                 else
                 {
                     if (skipType == SkipType.Sunrise)
                     {
-                        pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.ThemeSwitchPauseUntilSunset})";
+                        pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.ThemeSwitchPauseUntilSunset})";
                     }
                     else if (skipType == SkipType.Sunset)
                     {
-                        pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.ThemeSwitchPause} ({AdmProperties.Resources.ThemeSwitchPauseUntilSunrise})";
+                        pauseThemeSwitchItem.Text = $"{AdmProperties.Resources.TrayMenuItemThemeSwitchPause} ({AdmProperties.Resources.ThemeSwitchPauseUntilSunrise})";
                     }
                     else
                     {
-                        pauseThemeSwitchItem.Text = AdmProperties.Resources.ThemeSwitchPause;
+                        pauseThemeSwitchItem.Text = AdmProperties.Resources.TrayMenuItemThemeSwitchPause;
                     }
                 }
             }           

--- a/AutoDarkModeSvc/Service.cs
+++ b/AutoDarkModeSvc/Service.cs
@@ -74,8 +74,8 @@ namespace AutoDarkModeSvc
             pauseThemeSwitchItem.Name = "pauseThemeSwitch";
             forceDarkMenuItem.Text = AdmProperties.Resources.TrayMenuItemForceDarkTheme;
             forceLightMenuItem.Text = AdmProperties.Resources.TrayMenuItemForceLightTheme;
-            autoThemeSwitchingItem.Text = AdmProperties.Resources.AutomaticThemeSwitch;
-            toggleThemeItem.Text = AdmProperties.Resources.ToggleTheme;
+            autoThemeSwitchingItem.Text = AdmProperties.Resources.TrayMenuItemAutomaticThemeSwitch;
+            toggleThemeItem.Text = AdmProperties.Resources.TrayMenuItemToggleTheme;
 
             NotifyIcon = new NotifyIcon();
             state.SetNotifyIcon(NotifyIcon);
@@ -134,7 +134,7 @@ namespace AutoDarkModeSvc
 
         private void InitTray()
         {
-            ToolStripMenuItem exitMenuItem = new(AdmProperties.Resources.msgClose);
+            ToolStripMenuItem exitMenuItem = new(AdmProperties.Resources.TrayMenuItemClose);
             ToolStripMenuItem openConfigDirItem = new(AdmProperties.Resources.TrayMenuItemOpenConfigDir);
 
             exitMenuItem.Click += new EventHandler(RequestExit);


### PR DESCRIPTION
[Access keys](https://learn.microsoft.com/en-us/windows/apps/design/input/access-keys) allow quickly selecting an option in a menu using only the keyboard. Access keys are defined with an ampersand `&` just before the desired character.

For my use case, this allows very quick access to toggling the theme and forcing light or dark theme. Previously, I would have to right click on the tray icon, and then snipe the buttons with my mouse. Access keys allow me to right click, and then press the desired key: <kbd>T</kbd> for `Toggle theme`, <kbd>L</kbd> for `Force Light Theme`, etc.

For me, using access keys is much faster, and adding access keys does not impede existing point-and-click usage.

How the access keys display (notice the underlined characters):

![image](https://user-images.githubusercontent.com/16479013/211898949-7181b3e0-3163-46a2-b868-572a0ad0ba2f.png)

Please double-check that I've done the translations correctly, I've never used the translation system you use before.
Would it be possible to tag the copied translations as 'needs retranslation'? Or is that something that will happen automatically?