### PR TITLE
Update PageSettings.xaml

### DIFF
--- a/AutoDarkModeApp/Pages/PageSettings.xaml
+++ b/AutoDarkModeApp/Pages/PageSettings.xaml
@@ -393,16 +393,13 @@
                                   Content="{x:Static p:Resources.UpdatesComboBoxAtStart}"
                                   Click="CheckBoxUpdateOnStart_Click" />
 
-
                         <CheckBox x:Name="CheckBoxAutoInstall"
-                                  Margin="30,10,0,0"
+                                  Margin="0,10,0,0"
                                   Content="{x:Static p:Resources.UpdatesCheckBoxAutoInstall}"
                                   Click="CheckBoxAutoInstall_Click" />
 
-
-
                         <CheckBox x:Name="CheckBoxUpdateSilent"
-                                  Margin="30,10,0,0"
+                                  Margin="0,10,0,0"
                                   Content="{x:Static p:Resources.UpdatesCheckBoxSilent}"
                                   Click="CheckBoxUpdateSilent_Click" />
                     </StackPanel>


### PR DESCRIPTION
Extra margin in checkboxes in Settings Page Updates section might have implied that the options are nested, while they are not.