### PR TITLE
Code quality: About SystemAreasPage

### DIFF
--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -942,4 +942,13 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="AddApps" xml:space="preserve">
     <value>Start typing to add any apps</value>
   </data>
+  <data name="AppMode" xml:space="preserve">
+    <value>App mode</value>
+  </data>
+  <data name="WindowsMode" xml:space="preserve">
+    <value>Windows mode</value>
+  </data>
+  <data name="WindowsColorsSetting" xml:space="preserve">
+    <value>Personalized colors setting of Windows</value>
+  </data>
 </root>

--- a/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
@@ -38,10 +38,13 @@ public partial class SystemAreasViewModel : ObservableRecipient
     public partial SystemSwitchMode SystemSwitchComponentMode { get; set; }
 
     [ObservableProperty]
-    public partial bool IsAdaptiveTaskbarAccent { get; set; }
+    public partial bool AccentColorForTaskbarSettingsCardVisible { get; set; }
 
     [ObservableProperty]
     public partial bool IsTaskbarColorOnAdaptive { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsAdaptiveTaskbarAccent { get; set; }
 
     [ObservableProperty]
     public partial bool IsAdaptiveTaskbarAccentOnLight { get; set; }
@@ -114,12 +117,14 @@ public partial class SystemAreasViewModel : ObservableRecipient
                 Mode.AccentOnly => SystemSwitchMode.AccentOnly,
                 _ => SystemSwitchMode.Disabled,
             };
-            IsAdaptiveTaskbarAccent = SystemSwitchComponentMode == SystemSwitchMode.AccentOnly;
         }
         else
         {
             SystemSwitchComponentMode = SystemSwitchMode.Disabled;
         }
+        AccentColorForTaskbarSettingsCardVisible =
+            SystemSwitchComponentMode != SystemSwitchMode.AlwaysLight && SystemSwitchComponentMode != SystemSwitchMode.AccentOnly && SystemSwitchComponentMode != SystemSwitchMode.Disabled;
+        IsAdaptiveTaskbarAccent = SystemSwitchComponentMode == SystemSwitchMode.AccentOnly;
 
         IsTaskbarColorOnAdaptive = _builder.Config.SystemSwitch.Component.TaskbarColorOnAdaptive;
         if (_builder.Config.SystemSwitch.Component.TaskbarColorWhenNonAdaptive == Theme.Light)
@@ -208,6 +213,8 @@ public partial class SystemAreasViewModel : ObservableRecipient
         {
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
         }
+
+        RequestThemeSwitch();
     }
 
     partial void OnSystemSwitchComponentModeChanged(SystemSwitchMode value)
@@ -226,20 +233,15 @@ public partial class SystemAreasViewModel : ObservableRecipient
                 SystemSwitchMode.AccentOnly => Mode.AccentOnly,
                 _ => Mode.Switch,
             };
-            IsAdaptiveTaskbarAccent = value == SystemSwitchMode.AccentOnly;
         }
         else
         {
             _builder.Config.SystemSwitch.Enabled = false;
         }
-    }
+        AccentColorForTaskbarSettingsCardVisible =
+            SystemSwitchComponentMode != SystemSwitchMode.AlwaysLight && SystemSwitchComponentMode != SystemSwitchMode.AccentOnly && SystemSwitchComponentMode != SystemSwitchMode.Disabled;
+        IsAdaptiveTaskbarAccent = value == SystemSwitchMode.AccentOnly;
 
-    partial void OnIsTaskbarColorOnAdaptiveChanged(bool value)
-    {
-        if (_isInitializing)
-            return;
-
-        _builder.Config.SystemSwitch.Component.TaskbarColorOnAdaptive = value;
         try
         {
             _builder.Save();
@@ -248,6 +250,27 @@ public partial class SystemAreasViewModel : ObservableRecipient
         {
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
         }
+
+        RequestThemeSwitch();
+    }
+
+    partial void OnIsTaskbarColorOnAdaptiveChanged(bool value)
+    {
+        if (_isInitializing)
+            return;
+
+        _builder.Config.SystemSwitch.Component.TaskbarColorOnAdaptive = value;
+
+        try
+        {
+            _builder.Save();
+        }
+        catch (Exception ex)
+        {
+            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
+        }
+
+        RequestThemeSwitch();
     }
 
     partial void OnIsAdaptiveTaskbarAccentOnLightChanged(bool value)
@@ -298,6 +321,7 @@ public partial class SystemAreasViewModel : ObservableRecipient
             return;
 
         _builder.Config.SystemSwitch.Component.DWMPrevalenceSwitch = value;
+
         try
         {
             _builder.Save();

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -17,9 +17,10 @@
         <Grid x:Name="ContentArea" Margin="{StaticResource NavigationViewPageContentMargin}">
             <StackPanel Style="{StaticResource PageBaseStackPanelStyle}">
 
-                <!--  Apps  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Set}" />
-                <controls:SettingsCard Header="{helpers:ResourceString Name=SystemAreas}" HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=SystemAreas}" />
+
+                <!--  App Mode  -->
+                <controls:SettingsCard Header="{helpers:ResourceString Name=AppMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
                     <ComboBox SelectedIndex="{x:Bind ViewModel.AppsSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
                         <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
@@ -28,8 +29,8 @@
                     </ComboBox>
                 </controls:SettingsCard>
 
-                <!--  System  -->
-                <controls:SettingsExpander Header="{helpers:ResourceString Name=System}" HeaderIcon="{ui:FontIcon Glyph=&#xE770;}">
+                <!--  Windows mode  -->
+                <controls:SettingsExpander Header="{helpers:ResourceString Name=WindowsMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE770;}">
                     <ComboBox SelectedIndex="{x:Bind ViewModel.SystemSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
                         <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
@@ -39,12 +40,12 @@
                     </ComboBox>
 
                     <controls:SettingsExpander.Items>
-                        <controls:SettingsCard>
+                        <controls:SettingsCard Visibility="{x:Bind ViewModel.AccentColorForTaskbarSettingsCardVisible, Mode=OneWay}">
                             <controls:SettingsCard.Header>
                                 <CheckBox Content="{helpers:ResourceString Name=AccentColorForTaskbar}" IsChecked="{x:Bind ViewModel.IsTaskbarColorOnAdaptive, Mode=TwoWay}" />
                             </controls:SettingsCard.Header>
                         </controls:SettingsCard>
-                        <controls:SettingsCard>
+                        <controls:SettingsCard Visibility="{x:Bind ViewModel.IsAdaptiveTaskbarAccent, Mode=OneWay}">
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
                                     <CheckBox
@@ -87,6 +88,9 @@
                 <controls:SettingsCard Header="{helpers:ResourceString Name=ColorFilter}" HeaderIcon="{ui:FontIcon Glyph=&#xE790;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsColorFilterSwitch, Mode=TwoWay}" />
                 </controls:SettingsCard>
+
+                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Links}" />
+                <HyperlinkButton Click="WindowsColorsSetingHyperlinkButton_Click" Content="{helpers:ResourceString Name=WindowsColorsSetting}" />
 
             </StackPanel>
         </Grid>

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml.cs
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml.cs
@@ -12,4 +12,9 @@ public sealed partial class SystemAreasPage : Page
         ViewModel = App.GetService<SystemAreasViewModel>();
         InitializeComponent();
     }
+
+    private async void WindowsColorsSetingHyperlinkButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        await Windows.System.Launcher.LaunchUriAsync(new Uri("ms-settings:colors"));
+    }
 }


### PR DESCRIPTION
### Description

- Change the text to match Windows settings #955 
- Redesign the display logic of SettingCard, that is, hide it directly when it is disabled instead of displaying a completely inoperable SettingCard
- Add HyperlinkButton link to Windows settings -> Personalization -> Colors
- Fix the code error, the theme will not change immediately after changing the settings