### PR TITLE
Code quality: About WallpaperPickerPage

### DIFF
--- a/AutoDarkModeApp/ViewModels/WallpaperPickerViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/WallpaperPickerViewModel.cs
@@ -11,7 +11,6 @@ using CommunityToolkit.WinUI.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Xaml.Navigation;
 
 namespace AutoDarkModeApp.ViewModels;
 
@@ -379,11 +378,5 @@ public partial class WallpaperPickerViewModel : ObservableRecipient
         {
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "WallpaperPickerPage");
         }
-    }
-
-    internal void OnViewModelNavigatedFrom(NavigationEventArgs e)
-    {
-        StateUpdateHandler.OnConfigUpdate -= HandleConfigUpdate;
-        StateUpdateHandler.StopConfigWatcher();
     }
 }

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -64,7 +64,7 @@
                                 <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_Picture}" />
                                 <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_PictureMM}" />
                                 <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_SolidColor}" />
-                                <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_Spotlight}" />
+                                <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_Spotlight}" IsEnabled="{x:Bind ViewModel.SpotlightEnabled}" />
                             </RadioButtons>
                         </controls:SettingsCard>
 

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -36,8 +36,7 @@
                         Width="320"
                         Height="180"
                         Source="{x:Bind ViewModel.GlobalWallpaperSource, Mode=OneWay}"
-                        Stretch="{x:Bind ViewModel.SelectWallpaperFillingMode, Converter={StaticResource EnumToStretchConverter}, Mode=OneWay}"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                        Stretch="{x:Bind ViewModel.SelectWallpaperFillingMode, Converter={StaticResource EnumToStretchConverter}, Mode=OneWay}" />
                 </Border>
 
                 <!--  Desktop background  -->
@@ -58,7 +57,7 @@
                     </ComboBox>
 
                     <controls:SettingsExpander.Items>
-                        <!--  Background Type  -->
+                        <!--  Background type  -->
                         <controls:SettingsCard ContentAlignment="Left">
                             <RadioButtons SelectedIndex="{x:Bind ViewModel.CurrentDisplayMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
                                 <RadioButton Content="{helpers:ResourceString Name=WallpaperMode_Picture}" />
@@ -75,6 +74,19 @@
                                 HorizontalAlignment="Right"
                                 Command="{x:Bind ViewModel.PickFileCommand}"
                                 Content="{helpers:ResourceString Name=BrowsePhotos}" />
+                        </controls:SettingsCard>
+
+                        <!--  Picture path  -->
+                        <controls:SettingsCard Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
+                            <controls:SettingsCard.Header>
+                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <TextBlock Text="{helpers:ResourceString Name=PathAt}" />
+                                    <TextBlock
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        IsTextSelectionEnabled="True"
+                                        Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                                </StackPanel>
+                            </controls:SettingsCard.Header>
                         </controls:SettingsCard>
 
                         <!--  Picture fit  -->

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -113,11 +113,10 @@
                         <!--  Color  -->
                         <controls:SettingsCard Header="{helpers:ResourceString Name=Color}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowColorSettings, Mode=OneWay}">
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <!--  TODO: Replace Content to Resource  -->
                                 <Button
                                     MinWidth="120"
                                     Click="CheckColorButton_Click"
-                                    Content="Select color" />
+                                    Content="{helpers:ResourceString Name=SelectColor}" />
                             </StackPanel>
                         </controls:SettingsCard>
 
@@ -127,19 +126,6 @@
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
-
-
-                <!--  TODO: follow https://learn.microsoft.com/windows/apps/design/controls/dialogs-and-flyouts/dialogs  -->
-                <!--  Color Picker Dialog  -->
-                <ContentDialog
-                    x:Name="ColorPickerContentDialog"
-                    CloseButtonText="{helpers:ResourceString Name=Cancel}"
-                    DefaultButton="Primary"
-                    PrimaryButtonText="{helpers:ResourceString Name=Set}">
-                    <StackPanel>
-                        <ColorPicker x:Name="CheckColorColorPicker" />
-                    </StackPanel>
-                </ContentDialog>
 
             </StackPanel>
         </Grid>

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
@@ -1,12 +1,14 @@
 ﻿using AutoDarkModeApp.Contracts.Services;
 using AutoDarkModeApp.Helpers;
 using AutoDarkModeApp.Services;
+using AutoDarkModeApp.UserControls;
 using AutoDarkModeApp.Utils.Handlers;
 using AutoDarkModeApp.ViewModels;
 using AutoDarkModeLib;
 using AutoDarkModeLib.ComponentSettings.Base;
 using AutoDarkModeSvc.Communication;
 using CommunityToolkit.WinUI.Helpers;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace AutoDarkModeApp.Views;
@@ -115,23 +117,37 @@ public sealed partial class WallpaperPickerPage : Page
 
     private async void CheckColorButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        CheckColorColorPicker.Color =
-            ViewModel.SelectWallpaperThemeMode == Microsoft.UI.Xaml.ApplicationTheme.Light
-                ? _builder.Config.WallpaperSwitch.Component.SolidColors.Light.ToColor()
-                : _builder.Config.WallpaperSwitch.Component.SolidColors.Dark.ToColor();
-
-        var result = await ColorPickerContentDialog.ShowAsync();
+        var dialogContent = new ColorPickerDialogContentControl()
+        {
+            CustomColor =
+                ViewModel.SelectWallpaperThemeMode == Microsoft.UI.Xaml.ApplicationTheme.Light
+                    ? _builder.Config.WallpaperSwitch.Component.SolidColors.Light.ToColor()
+                    : _builder.Config.WallpaperSwitch.Component.SolidColors.Dark.ToColor(),
+        };
+        var colorPickerDialog = new ContentDialog()
+        {
+            XamlRoot = this.XamlRoot,
+            Style = Application.Current.Resources["DefaultContentDialogStyle"] as Style,
+            Title = "ChooseCustomColor".GetLocalized(),
+            CloseButtonText = "Cancel".GetLocalized(),
+            PrimaryButtonText = "Set".GetLocalized(),
+            DefaultButton = ContentDialogButton.Primary,
+            Content = dialogContent,
+        };
+        var result = await colorPickerDialog.ShowAsync();
         if (result == ContentDialogResult.Primary)
         {
             if (ViewModel.SelectWallpaperThemeMode == Microsoft.UI.Xaml.ApplicationTheme.Light)
             {
-                _builder.Config.WallpaperSwitch.Component.SolidColors.Light = CheckColorColorPicker.Color.ToHex();
+                _builder.Config.WallpaperSwitch.Component.SolidColors.Light = dialogContent.CustomColor.ToHex();
             }
             else
             {
-                _builder.Config.WallpaperSwitch.Component.SolidColors.Dark = CheckColorColorPicker.Color.ToHex();
+                _builder.Config.WallpaperSwitch.Component.SolidColors.Dark = dialogContent.CustomColor.ToHex();
             }
+            ViewModel.ColorPreviewBorderBackground = new Microsoft.UI.Xaml.Media.SolidColorBrush(dialogContent.CustomColor);
         }
+
         try
         {
             _builder.Save();

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
@@ -8,7 +8,6 @@ using AutoDarkModeLib.ComponentSettings.Base;
 using AutoDarkModeSvc.Communication;
 using CommunityToolkit.WinUI.Helpers;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Navigation;
 
 namespace AutoDarkModeApp.Views;
 
@@ -32,18 +31,20 @@ public sealed partial class WallpaperPickerPage : Page
         // Generate a list with all installed Monitors, select the first one
         List<MonitorSettings> monitors = _builder.Config.WallpaperSwitch.Component.Monitors;
         var disconnected = new List<MonitorSettings>();
-        var connected = monitors.Where(m =>
-        {
-            // Preload tostring to avoid dropdown opening lag
-            m.ToString();
-            // Return monitors connecte to system connected monitors
-            if (m.Connected)
+        var connected = monitors
+            .Where(m =>
             {
-                return true;
-            }
-            disconnected.Add(m);
-            return false;
-        }).ToList();
+                // Preload tostring to avoid dropdown opening lag
+                m.ToString();
+                // Return monitors connecte to system connected monitors
+                if (m.Connected)
+                {
+                    return true;
+                }
+                disconnected.Add(m);
+                return false;
+            })
+            .ToList();
 
         foreach (var monitor in disconnected)
         {
@@ -87,9 +88,10 @@ public sealed partial class WallpaperPickerPage : Page
 
     private async void CheckColorButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        CheckColorColorPicker.Color = ViewModel.SelectWallpaperThemeMode == Microsoft.UI.Xaml.ApplicationTheme.Light
-            ? _builder.Config.WallpaperSwitch.Component.SolidColors.Light.ToColor()
-            : _builder.Config.WallpaperSwitch.Component.SolidColors.Dark.ToColor();
+        CheckColorColorPicker.Color =
+            ViewModel.SelectWallpaperThemeMode == Microsoft.UI.Xaml.ApplicationTheme.Light
+                ? _builder.Config.WallpaperSwitch.Component.SolidColors.Light.ToColor()
+                : _builder.Config.WallpaperSwitch.Component.SolidColors.Dark.ToColor();
 
         var result = await ColorPickerContentDialog.ShowAsync();
         if (result == ContentDialogResult.Primary)
@@ -117,6 +119,4 @@ public sealed partial class WallpaperPickerPage : Page
     {
         await Windows.System.Launcher.LaunchUriAsync(new Uri("ms-settings:personalization-background"));
     }
-
-    protected override void OnNavigatedFrom(NavigationEventArgs e) => ViewModel.OnViewModelNavigatedFrom(e);
 }

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml.cs
@@ -23,7 +23,34 @@ public sealed partial class WallpaperPickerPage : Page
         ViewModel = App.GetService<WallpaperPickerViewModel>();
         InitializeComponent();
 
+        if (_builder.Config.WallpaperSwitch.Component.Monitors.Count == 0)
+            Task.Run(async () => await DetectMonitorsAsync());
+
         DispatcherQueue.TryEnqueue(LoadMonitors);
+    }
+
+    private async Task DetectMonitorsAsync()
+    {
+        try
+        {
+            string result = await MessageHandler.Client.SendMessageAndGetReplyAsync(Command.DetectMonitors);
+            if (result != StatusCode.Ok)
+            {
+                throw new SwitchThemeException(result, "WallpaperPickerPage");
+            }
+            try
+            {
+                _builder.Load();
+            }
+            catch (Exception ex)
+            {
+                await _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "Constructor");
+            }
+        }
+        catch (Exception ex)
+        {
+            await _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "Constructor");
+        }
     }
 
     private void LoadMonitors()

--- a/AutoDarkModeLib/Enums.cs
+++ b/AutoDarkModeLib/Enums.cs
@@ -111,6 +111,8 @@ public enum WindowsBuilds : int
     MinBuildForNewFeatures = 19044,
     Win11_RC = 22000,
     Win11_22H2 = 22621,
+    Win11_23H2 = 22631,
+    Win11_24H2 = 26100,
 }
 
 public enum WindowsBuildsUbr : int


### PR DESCRIPTION
### Description

- Delete the old navigation code.
- Fixed the problem that switching monitors in multi-monitor mode would not refresh wallpaper preview.
- Removed the ToolTip when the mouse hovered to display the wallpaper path, and used the TextBlock instead. More intuitive, users can also copy the path.
- Show a preview of Spotlight wallpaper (not strictly tested, the existing code is used as a reference, because each Win11 version reads differently).
- Instead of Dialog, use UsersControls to get the proper dialog opening and closing animation (WinUI Bug).

### Screenshots

#### Path

<img width="1172" height="780" alt="image" src="https://github.com/user-attachments/assets/0861c453-cfbc-4d0a-a152-1358d6c5fe76" />

#### Spotlight

<img width="1173" height="761" alt="image" src="https://github.com/user-attachments/assets/49ec402e-678d-4449-be4d-c405d17f19f6" />

#### ColorPicker

![PixPin_2025-08-04_13-11-36](https://github.com/user-attachments/assets/7060344b-e602-413f-87a9-a42d6ae044f2)
