### PR TITLE
Fix: SettingsCard header be cut off

### DIFF
--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -122,9 +122,16 @@
 
                         <!--  Picture path  -->
                         <controls:SettingsCard
-                            Description="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}"
+                            HorizontalContentAlignment="Stretch"
+                            ContentAlignment="Vertical"
                             Header="{helpers:ResourceString Name=Path}"
-                            Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}" />
+                            Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
+                            <TextBlock
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                IsTextSelectionEnabled="True"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                        </controls:SettingsCard>
 
                         <!--  Picture fit  -->
                         <controls:SettingsCard Header="{helpers:ResourceString Name=Position}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowFillingWaySettings, Mode=OneWay}">

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -112,7 +112,10 @@
                         <!--  Picture path  -->
                         <controls:SettingsCard Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
                             <controls:SettingsCard.Header>
-                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                <StackPanel
+                                    Margin="0,0,-24,0"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
                                     <TextBlock Text="{helpers:ResourceString Name=PathAt}" />
                                     <TextBlock
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -100,6 +100,17 @@
                             </RadioButtons>
                         </controls:SettingsCard>
 
+                        <!--  Monitor  -->
+                        <controls:SettingsCard Header="{helpers:ResourceString Name=Monitor}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowMonitorSettings, Mode=OneWay}">
+                            <controls:SettingsCard.Description>
+                                <HyperlinkButton Click="RemoveDisconnectedMonitorsHyperlinkButton_Click" Content="{helpers:ResourceString Name=RemoveDisconnected}" />
+                            </controls:SettingsCard.Description>
+                            <ComboBox
+                                x:Name="MonitorsComboBox"
+                                HorizontalAlignment="Right"
+                                SelectedItem="{x:Bind ViewModel.SelectMonitor, Mode=TwoWay}" />
+                        </controls:SettingsCard>
+
                         <!--  Picture  -->
                         <controls:SettingsCard Header="{helpers:ResourceString Name=ChooseWallpaper}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
                             <Button
@@ -110,21 +121,10 @@
                         </controls:SettingsCard>
 
                         <!--  Picture path  -->
-                        <controls:SettingsCard Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
-                            <controls:SettingsCard.Header>
-                                <StackPanel
-                                    Margin="0,0,-24,0"
-                                    Orientation="Horizontal"
-                                    Spacing="8">
-                                    <TextBlock Text="{helpers:ResourceString Name=PathAt}" />
-                                    <TextBlock
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        IsTextSelectionEnabled="True"
-                                        Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}"
-                                        ToolTipService.ToolTip="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
-                                </StackPanel>
-                            </controls:SettingsCard.Header>
-                        </controls:SettingsCard>
+                        <controls:SettingsCard
+                            Description="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}"
+                            Header="{helpers:ResourceString Name=Path}"
+                            Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}" />
 
                         <!--  Picture fit  -->
                         <controls:SettingsCard Header="{helpers:ResourceString Name=Position}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowFillingWaySettings, Mode=OneWay}">
@@ -134,17 +134,6 @@
                                 <ComboBoxItem Content="{helpers:ResourceString Name=FitMode_Fit}" />
                                 <ComboBoxItem Content="{helpers:ResourceString Name=FitMode_Fill}" />
                             </ComboBox>
-                        </controls:SettingsCard>
-
-                        <!--  Monitor  -->
-                        <controls:SettingsCard Header="{helpers:ResourceString Name=Monitor}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowMonitorSettings, Mode=OneWay}">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <HyperlinkButton Click="RemoveDisconnectedMonitorsHyperlinkButton_Click" Content="{helpers:ResourceString Name=RemoveDisconnected}" />
-                                <ComboBox
-                                    x:Name="MonitorsComboBox"
-                                    HorizontalAlignment="Right"
-                                    SelectedItem="{x:Bind ViewModel.SelectMonitor, Mode=TwoWay}" />
-                            </StackPanel>
                         </controls:SettingsCard>
 
                         <!--  Color  -->

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -121,16 +121,20 @@
                         </controls:SettingsCard>
 
                         <!--  Picture path  -->
-                        <controls:SettingsCard
-                            HorizontalContentAlignment="Stretch"
-                            ContentAlignment="Vertical"
-                            Header="{helpers:ResourceString Name=Path}"
-                            Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
-                            <TextBlock
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                IsTextSelectionEnabled="True"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                        <controls:SettingsCard Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
+                            <controls:SettingsCard.Header>
+                                <StackPanel
+                                    Margin="0,0,-24,0"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
+                                    <TextBlock Text="{helpers:ResourceString Name=PathAt}" />
+                                    <TextBlock
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        IsTextSelectionEnabled="True"
+                                        Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}"
+                                        ToolTipService.ToolTip="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                                </StackPanel>
+                            </controls:SettingsCard.Header>
                         </controls:SettingsCard>
 
                         <!--  Picture fit  -->

--- a/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
+++ b/AutoDarkModeApp/Views/WallpaperPickerPage.xaml
@@ -110,11 +110,17 @@
                         </controls:SettingsCard>
 
                         <!--  Picture path  -->
-                        <controls:SettingsCard Header="{helpers:ResourceString Name=Path}" Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
-                            <TextBlock
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                IsTextSelectionEnabled="True"
-                                Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                        <controls:SettingsCard Visibility="{x:Bind ViewModel.CurrentDisplayFlags, Converter={StaticResource FlagsToVisibilityConverter}, ConverterParameter=ShowImageSettings, Mode=OneWay}">
+                            <controls:SettingsCard.Header>
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock Text="{helpers:ResourceString Name=PathAt}" />
+                                    <TextBlock
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        IsTextSelectionEnabled="True"
+                                        Text="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}"
+                                        ToolTipService.ToolTip="{x:Bind ViewModel.GlobalWallpaperPath, Mode=OneWay}" />
+                                </StackPanel>
+                            </controls:SettingsCard.Header>
                         </controls:SettingsCard>
 
                         <!--  Picture fit  -->


### PR DESCRIPTION
### Description

- Fixed that when the path is too long, the Textblock will overwrite the Header of the SettingsCard, which will not be displayed.
- Moved **Monitor** up above image setting.

### Screenshots

<img width="666" height="670" alt="image" src="https://github.com/user-attachments/assets/bc7a3742-6ccd-4233-bee8-13dabef3130b" />
