### PR TITLE
Feature: Allow setting Ignore Color flag in theme mode

### DIFF
--- a/AutoDarkModeApp/Strings/ar/Resources.resw
+++ b/AutoDarkModeApp/Strings/ar/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -975,5 +975,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/cs/Resources.resw
+++ b/AutoDarkModeApp/Strings/cs/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Nainstalovaná verze: {0}, nová verze: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/de/Resources.resw
+++ b/AutoDarkModeApp/Strings/de/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Farbe ignorieren</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/el-gr/Resources.resw
+++ b/AutoDarkModeApp/Strings/el-gr/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -901,6 +901,9 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="Path" xml:space="preserve">
     <value>Path</value>
   </data>
+  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
+    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
+  </data>
   <data name="Beta" xml:space="preserve">
     <value>Beta</value>
   </data>
@@ -967,7 +970,7 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
   </data>
-  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/es/Resources.resw
+++ b/AutoDarkModeApp/Strings/es/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versión instalada actualmente: {0}, nueva versión: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fr/Resources.resw
+++ b/AutoDarkModeApp/Strings/fr/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Version installée : {0}, nouvelle version : {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/he/Resources.resw
+++ b/AutoDarkModeApp/Strings/he/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Click "Yes" to open a new browser window.
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/id/Resources.resw
+++ b/AutoDarkModeApp/Strings/id/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versi saat ini: {0}, Versi terbaru: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/it/Resources.resw
+++ b/AutoDarkModeApp/Strings/it/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versione attualmente installata: {0}, nuova versione: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ja/Resources.resw
+++ b/AutoDarkModeApp/Strings/ja/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -741,6 +741,9 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="SelectLightCursor" xml:space="preserve">
     <value>ライト用のカーソルを選択</value>
   </data>
+  <data name="Set" xml:space="preserve">
+    <value>Set</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>設定</value>
   </data>
@@ -888,11 +891,17 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
     <value>Background</value>
     <comment>match Windows Settings</comment>
   </data>
+  <data name="SelectColor" xml:space="preserve">
+    <value>Select a color</value>
+  </data>
   <data name="DisableWindowsManagesTheme" xml:space="preserve">
     <value>Disable Windows manages your theme</value>
   </data>
   <data name="Path" xml:space="preserve">
     <value>Path</value>
+  </data>
+  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
+    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
   </data>
   <data name="Beta" xml:space="preserve">
     <value>ベータ版</value>
@@ -906,20 +915,11 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="Language" xml:space="preserve">
     <value>言語</value>
   </data>
-  <data name="Stable" xml:space="preserve">
-    <value>安定版</value>
-  </data>
-  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
-  </data>
-  <data name="Set" xml:space="preserve">
-    <value>Set</value>
-  </data>
-  <data name="SelectColor" xml:space="preserve">
-    <value>Select a color</value>
-  </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
     <value>Go to Windows Spotlight settings</value>
+  </data>
+  <data name="Stable" xml:space="preserve">
+    <value>安定版</value>
   </data>
   <data name="Switch" xml:space="preserve">
     <value>Switch</value>
@@ -968,5 +968,8 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ko/Resources.resw
+++ b/AutoDarkModeApp/Strings/ko/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nb-no/Resources.resw
+++ b/AutoDarkModeApp/Strings/nb-no/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nl/Resources.resw
+++ b/AutoDarkModeApp/Strings/nl/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Momenteel geïnstalleerde versie: {0}, nieuwe versie: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pl/Resources.resw
+++ b/AutoDarkModeApp/Strings/pl/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Obecnie zainstalowana wersja: {0}, nowa wersja: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-br/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-br/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versão instalada atualmente: {0}, nova versão: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-pt/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-pt/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versão instalada: {0}, Versão nova: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ro/Resources.resw
+++ b/AutoDarkModeApp/Strings/ro/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Versiunea instalată în prezent: {0}, versiune nouă: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ru/Resources.resw
+++ b/AutoDarkModeApp/Strings/ru/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sr/Resources.resw
+++ b/AutoDarkModeApp/Strings/sr/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Trenutno instalirana verzija: {0}, nova verzija: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sv/Resources.resw
+++ b/AutoDarkModeApp/Strings/sv/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Installerad version: {0}, ny version: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/tr/Resources.resw
+++ b/AutoDarkModeApp/Strings/tr/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Bunu indirmek istiyor musunuz?
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/uk/Resources.resw
+++ b/AutoDarkModeApp/Strings/uk/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -972,5 +972,8 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Не затримується</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/vi/Resources.resw
+++ b/AutoDarkModeApp/Strings/vi/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@ Phiên bản hiện tại của bạn: {0}, phiên bản mới: {1}</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hans/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hans/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -735,6 +735,9 @@
   <data name="SelectLightCursor" xml:space="preserve">
     <value>选择浅色光标</value>
   </data>
+  <data name="Set" xml:space="preserve">
+    <value>设定</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>设置</value>
   </data>
@@ -882,11 +885,17 @@
     <value>背景</value>
     <comment>match Windows Settings</comment>
   </data>
+  <data name="SelectColor" xml:space="preserve">
+    <value>选择颜色</value>
+  </data>
   <data name="DisableWindowsManagesTheme" xml:space="preserve">
     <value>停用 Windows 管理您的主题</value>
   </data>
   <data name="Path" xml:space="preserve">
     <value>路径</value>
+  </data>
+  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
+    <value>自动启动已在任务管理器的“启动应用”标签页中禁用。如果您想重新让 Auto Dark Mode 随 Windows 启动，请在那里重新启用。</value>
   </data>
   <data name="Beta" xml:space="preserve">
     <value>测试版</value>
@@ -900,20 +909,11 @@
   <data name="Language" xml:space="preserve">
     <value>语言</value>
   </data>
-  <data name="Stable" xml:space="preserve">
-    <value>稳定版</value>
-  </data>
-  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>自动启动已在任务管理器的“启动应用”标签页中禁用。如果您想重新让 Auto Dark Mode 随 Windows 启动，请在那里重新启用。</value>
-  </data>
-  <data name="Set" xml:space="preserve">
-    <value>设定</value>
-  </data>
-  <data name="SelectColor" xml:space="preserve">
-    <value>选择颜色</value>
-  </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
     <value>前往 Windows 聚焦设置</value>
+  </data>
+  <data name="Stable" xml:space="preserve">
+    <value>稳定版</value>
   </data>
   <data name="Switch" xml:space="preserve">
     <value>切换</value>
@@ -962,5 +962,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>未推迟</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -978,5 +978,8 @@
   </data>
   <data name="NotDelayed" xml:space="preserve">
     <value>Not Delayed</value>
+  </data>
+  <data name="IgnoreColor" xml:space="preserve">
+    <value>Ignore color</value>
   </data>
 </root>

--- a/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
@@ -27,7 +27,6 @@ public partial class SystemAreasViewModel : ObservableRecipient
         AdaptToSystem,
         AlwaysLight,
         AlwaysDark,
-        AccentOnly,
         Disabled,
     }
 
@@ -38,19 +37,13 @@ public partial class SystemAreasViewModel : ObservableRecipient
     public partial SystemSwitchMode SystemSwitchComponentMode { get; set; }
 
     [ObservableProperty]
-    public partial bool AccentColorForTaskbarSettingsCardVisible { get; set; }
+    public partial bool IsTaskbarColorSwitch { get; set; }
 
     [ObservableProperty]
-    public partial bool IsTaskbarColorOnAdaptive { get; set; }
+    public partial bool IsTaskbarAccentOnLight { get; set; }
 
     [ObservableProperty]
-    public partial bool IsAdaptiveTaskbarAccent { get; set; }
-
-    [ObservableProperty]
-    public partial bool IsAdaptiveTaskbarAccentOnLight { get; set; }
-
-    [ObservableProperty]
-    public partial bool IsAdaptiveTaskbarAccentOnDark { get; set; }
+    public partial bool IsTaskbarAccentOnDark { get; set; }
 
     [ObservableProperty]
     public partial bool IsDWMPrevalenceSwitch { get; set; }
@@ -114,7 +107,6 @@ public partial class SystemAreasViewModel : ObservableRecipient
                 Mode.Switch => SystemSwitchMode.AdaptToSystem,
                 Mode.LightOnly => SystemSwitchMode.AlwaysLight,
                 Mode.DarkOnly => SystemSwitchMode.AlwaysDark,
-                Mode.AccentOnly => SystemSwitchMode.AccentOnly,
                 _ => SystemSwitchMode.Disabled,
             };
         }
@@ -122,20 +114,17 @@ public partial class SystemAreasViewModel : ObservableRecipient
         {
             SystemSwitchComponentMode = SystemSwitchMode.Disabled;
         }
-        AccentColorForTaskbarSettingsCardVisible =
-            SystemSwitchComponentMode != SystemSwitchMode.AlwaysLight && SystemSwitchComponentMode != SystemSwitchMode.AccentOnly && SystemSwitchComponentMode != SystemSwitchMode.Disabled;
-        IsAdaptiveTaskbarAccent = SystemSwitchComponentMode == SystemSwitchMode.AccentOnly;
 
-        IsTaskbarColorOnAdaptive = _builder.Config.SystemSwitch.Component.TaskbarColorOnAdaptive;
-        if (_builder.Config.SystemSwitch.Component.TaskbarColorWhenNonAdaptive == Theme.Light)
+        IsTaskbarColorSwitch = _builder.Config.SystemSwitch.Component.TaskbarColorSwitch;
+        if (_builder.Config.SystemSwitch.Component.TaskbarColorDuring == Theme.Light)
         {
-            IsAdaptiveTaskbarAccentOnLight = true;
-            IsAdaptiveTaskbarAccentOnDark = false;
+            IsTaskbarAccentOnLight = true;
+            IsTaskbarAccentOnDark = false;
         }
         else
         {
-            IsAdaptiveTaskbarAccentOnLight = false;
-            IsAdaptiveTaskbarAccentOnDark = true;
+            IsTaskbarAccentOnLight = false;
+            IsTaskbarAccentOnDark = true;
         }
 
         IsDWMPrevalenceSwitch = _builder.Config.SystemSwitch.Component.DWMPrevalenceSwitch;
@@ -230,7 +219,6 @@ public partial class SystemAreasViewModel : ObservableRecipient
                 SystemSwitchMode.AdaptToSystem => Mode.Switch,
                 SystemSwitchMode.AlwaysLight => Mode.LightOnly,
                 SystemSwitchMode.AlwaysDark => Mode.DarkOnly,
-                SystemSwitchMode.AccentOnly => Mode.AccentOnly,
                 _ => Mode.Switch,
             };
         }
@@ -238,9 +226,6 @@ public partial class SystemAreasViewModel : ObservableRecipient
         {
             _builder.Config.SystemSwitch.Enabled = false;
         }
-        AccentColorForTaskbarSettingsCardVisible =
-            SystemSwitchComponentMode != SystemSwitchMode.AlwaysLight && SystemSwitchComponentMode != SystemSwitchMode.AccentOnly && SystemSwitchComponentMode != SystemSwitchMode.Disabled;
-        IsAdaptiveTaskbarAccent = value == SystemSwitchMode.AccentOnly;
 
         try
         {
@@ -254,12 +239,12 @@ public partial class SystemAreasViewModel : ObservableRecipient
         RequestThemeSwitch();
     }
 
-    partial void OnIsTaskbarColorOnAdaptiveChanged(bool value)
+    partial void OnIsTaskbarColorSwitchChanged(bool value)
     {
         if (_isInitializing)
             return;
 
-        _builder.Config.SystemSwitch.Component.TaskbarColorOnAdaptive = value;
+        _builder.Config.SystemSwitch.Component.TaskbarColorSwitch = value;
 
         try
         {
@@ -273,35 +258,35 @@ public partial class SystemAreasViewModel : ObservableRecipient
         RequestThemeSwitch();
     }
 
-    partial void OnIsAdaptiveTaskbarAccentOnLightChanged(bool value)
-    {
-        if (_isInitializing)
-            return;
-
-        if (value)
-        {
-            _builder.Config.SystemSwitch.Component.TaskbarColorWhenNonAdaptive = Theme.Light;
-        }
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
-        }
-
-        RequestThemeSwitch();
-    }
-
-    partial void OnIsAdaptiveTaskbarAccentOnDarkChanged(bool value)
+    partial void OnIsTaskbarAccentOnLightChanged(bool value)
     {
         if (_isInitializing)
             return;
 
         if (value)
         {
-            _builder.Config.SystemSwitch.Component.TaskbarColorWhenNonAdaptive = Theme.Dark;
+            _builder.Config.SystemSwitch.Component.TaskbarColorDuring = Theme.Light;
+        }
+        try
+        {
+            _builder.Save();
+        }
+        catch (Exception ex)
+        {
+            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
+        }
+
+        RequestThemeSwitch();
+    }
+
+    partial void OnIsTaskbarAccentOnDarkChanged(bool value)
+    {
+        if (_isInitializing)
+            return;
+
+        if (value)
+        {
+            _builder.Config.SystemSwitch.Component.TaskbarColorDuring = Theme.Dark;
         }
         try
         {

--- a/AutoDarkModeApp/ViewModels/ThemePickerViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/ThemePickerViewModel.cs
@@ -37,6 +37,9 @@ public partial class ThemePickerViewModel : ObservableRecipient
     public partial bool IgnoreSoundEnabled { get; set; }
 
     [ObservableProperty]
+    public partial bool IgnoreColorEnabled { get; set; }
+
+    [ObservableProperty]
     public partial bool IgnoreDesktopIconsEnabled { get; set; }
 
     public ThemePickerViewModel(IErrorService errorService)
@@ -72,6 +75,7 @@ public partial class ThemePickerViewModel : ObservableRecipient
         IgnoreCursorEnabled = flagsSet.Contains(ThemeApplyFlags.IgnoreCursor);
         IgnoreDesktopIconsEnabled = flagsSet.Contains(ThemeApplyFlags.IgnoreDesktopIcons);
         IgnoreSoundEnabled = flagsSet.Contains(ThemeApplyFlags.IgnoreSound);
+        IgnoreColorEnabled = flagsSet.Contains(ThemeApplyFlags.IgnoreColor);
 
         _isInitializing = false;
     }
@@ -90,6 +94,8 @@ public partial class ThemePickerViewModel : ObservableRecipient
             flags.Add(ThemeApplyFlags.IgnoreSound);
         if (IgnoreDesktopIconsEnabled == true)
             flags.Add(ThemeApplyFlags.IgnoreDesktopIcons);
+        if (IgnoreColorEnabled == true)
+            flags.Add(ThemeApplyFlags.IgnoreColor);
         _builder.Config.WindowsThemeMode.ApplyFlags = flags;
         try
         {
@@ -236,6 +242,11 @@ public partial class ThemePickerViewModel : ObservableRecipient
     }
 
     partial void OnIgnoreDesktopIconsEnabledChanged(bool value)
+    {
+        WriteSettings();
+    }
+
+    partial void OnIgnoreColorEnabledChanged(bool value)
     {
         WriteSettings();
     }

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -35,28 +35,21 @@
                         <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysDark}" />
-                        <ComboBoxItem Content="{helpers:ResourceString Name=AccentOnly}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=Disabled}" />
                     </ComboBox>
 
                     <controls:SettingsExpander.Items>
-                        <controls:SettingsCard Visibility="{x:Bind ViewModel.AccentColorForTaskbarSettingsCardVisible, Mode=OneWay}">
-                            <controls:SettingsCard.Header>
-                                <CheckBox Content="{helpers:ResourceString Name=AccentColorForTaskbar}" IsChecked="{x:Bind ViewModel.IsTaskbarColorOnAdaptive, Mode=TwoWay}" />
-                            </controls:SettingsCard.Header>
-                        </controls:SettingsCard>
-                        <controls:SettingsCard Visibility="{x:Bind ViewModel.IsAdaptiveTaskbarAccent, Mode=OneWay}">
+                        <controls:SettingsCard>
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
                                     <CheckBox
                                         x:Name="AdaptiveTaskbarAccentCheckBox"
                                         Content="{helpers:ResourceString Name=AdaptiveTaskbarAccent}"
-                                        IsChecked="{x:Bind ViewModel.IsAdaptiveTaskbarAccent, Mode=OneWay}"
-                                        IsEnabled="False" />
+                                              IsChecked="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}"/>
 
-                                    <RadioButtons IsEnabled="{x:Bind ViewModel.IsAdaptiveTaskbarAccent, Mode=OneWay}">
-                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}" IsChecked="{x:Bind ViewModel.IsAdaptiveTaskbarAccentOnLight, Mode=TwoWay}" />
-                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsAdaptiveTaskbarAccentOnDark, Mode=TwoWay}" />
+                                    <RadioButtons IsEnabled="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=OneWay}">
+                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}" IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnLight, Mode=TwoWay}" />
+                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnDark, Mode=TwoWay}" />
                                     </RadioButtons>
                                 </StackPanel>
                             </controls:SettingsCard.Header>

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml
@@ -72,6 +72,9 @@
                 <controls:SettingsCard ContentAlignment="Left">
                     <CheckBox Content="{helpers:ResourceString Name=IgnoreDesktopIcons}" IsChecked="{x:Bind ViewModel.IgnoreDesktopIconsEnabled, Mode=TwoWay}" />
                 </controls:SettingsCard>
+                <controls:SettingsCard ContentAlignment="Left">
+                    <CheckBox Content="{helpers:ResourceString Name=IgnoreColor}" IsChecked="{x:Bind ViewModel.IgnoreColorEnabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
 
             </StackPanel>
         </Grid>

--- a/AutoDarkModeLib/ComponentSettings/Base/SystemSwitchSettings.cs
+++ b/AutoDarkModeLib/ComponentSettings/Base/SystemSwitchSettings.cs
@@ -20,8 +20,8 @@ public class SystemSwitchSettings
 {
     public Mode Mode { get; set; }
     public int TaskbarSwitchDelay { get; set; } = 1200;
-    public bool TaskbarColorOnAdaptive { get; set; }
-    public Theme TaskbarColorWhenNonAdaptive { get; set; } = Theme.Light;
+    public bool TaskbarColorSwitch { get; set; }
+    public Theme TaskbarColorDuring { get; set; } = Theme.Light;
     public bool DWMPrevalenceSwitch { get; set; }
     public Theme DWMPrevalenceEnableTheme { get; set; } = Theme.Light;
 }

--- a/AutoDarkModeLib/Enums.cs
+++ b/AutoDarkModeLib/Enums.cs
@@ -30,7 +30,11 @@ public enum Theme
     Unknown = -1,
     Dark = 0,
     Light = 1,
-    Automatic = 2
+    /// <summary>
+    /// If resovle is set, ADM needs to determine the theme that the EventArgs should propagate.
+    /// This is the case during overrides (postpone, dark on battery etc)
+    /// </summary>
+    Resolve = 2
 };
 
 /// <summary>
@@ -59,7 +63,15 @@ public enum SwitchSource
     Startup,
     SystemUnlock,
     Api,
-    SystemTimeChanged
+    SystemTimeChanged,
+}
+
+public enum DwmRefreshSource
+{
+    ThemeManager,
+    ThemeHandler,
+    TaskbarColorSwitchComponent,
+    User
 }
 
 public enum ThemeOverrideSource

--- a/AutoDarkModeSvc/AutoDarkModeSvc.csproj
+++ b/AutoDarkModeSvc/AutoDarkModeSvc.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>11.0.0.15</Version>
+    <Version>11.0.0.16</Version>
     <AssemblyName>AutoDarkModeSvc</AssemblyName>
     <ApplicationIcon>..\adm_tray_new.ico</ApplicationIcon>
     <StartupObject>AutoDarkModeSvc.Program</StartupObject>

--- a/AutoDarkModeSvc/Core/ComponentManager.cs
+++ b/AutoDarkModeSvc/Core/ComponentManager.cs
@@ -50,6 +50,7 @@ class ComponentManager
     private readonly ISwitchComponent ColorizationSwitch;
     private readonly ISwitchComponent CursorSwitch;
     private readonly ISwitchComponent TouchKeyboardSwitch = new TouchKeyboardSwitch();
+    private readonly ISwitchComponent TaskbarColorSwitch;
 
     /// <summary>
     /// Instructs all components to refresh their settings objects by injecting a new settings object
@@ -65,6 +66,7 @@ class ComponentManager
         ColorizationSwitch?.RunUpdateSettingsState(Builder.Config.ColorizationSwitch);
         CursorSwitch?.RunUpdateSettingsState(Builder.Config.CursorSwitch);
         TouchKeyboardSwitch?.RunUpdateSettingsState(Builder.Config.TouchKeyboardSwitch);
+        TaskbarColorSwitch?.RunUpdateSettingsState(Builder.Config.SystemSwitch);
     }
 
     public void UpdateScriptSettings()
@@ -121,9 +123,11 @@ class ComponentManager
         {
             Logger.Info($"using colorization and cursor switcher for newer builds {(int)WindowsBuilds.MinBuildForNewFeatures} and up");
             ColorizationSwitch = new ColorizationSwitch();
-            Components.Add(ColorizationSwitch);
             CursorSwitch = new CursorSwitch();
+            TaskbarColorSwitch = new TaskbarColorSwitch();
+            Components.Add(ColorizationSwitch);
             Components.Add(CursorSwitch);
+            Components.Add(TaskbarColorSwitch);
         }
         UpdateSettings();
         UpdateScriptSettings();

--- a/AutoDarkModeSvc/Core/GlobalState.cs
+++ b/AutoDarkModeSvc/Core/GlobalState.cs
@@ -54,7 +54,7 @@ public class GlobalState
     /// </summary>
     public Theme InternalTheme
     {
-        get { return _requestedTheme; }
+        get => _requestedTheme;
         set
         {
             _requestedTheme = value;

--- a/AutoDarkModeSvc/Core/PostponeManager.cs
+++ b/AutoDarkModeSvc/Core/PostponeManager.cs
@@ -373,7 +373,7 @@ public class PostponeManager
         return new(itemDtos);
     }
 
-    public void GetPostonesFromDisk()
+    public void GetPostponesFromDisk()
     {
         try
         {

--- a/AutoDarkModeSvc/Core/ThemeManager.cs
+++ b/AutoDarkModeSvc/Core/ThemeManager.cs
@@ -82,8 +82,8 @@ static class ThemeManager
             }
         }
 
-        // process switches with a requested theme set before automatic ones
-        if (e.Theme != Theme.Automatic)
+        // process switches with a requested theme
+        if (e.Theme != Theme.Resolve)
         {
             UpdateTheme(e);
             return;
@@ -192,7 +192,7 @@ static class ThemeManager
     [MethodImpl(MethodImplOptions.Synchronized)]
     public static void UpdateTheme(SwitchEventArgs e)
     {
-        if (e.Theme == Theme.Unknown || e.Theme == Theme.Automatic)
+        if (e.Theme == Theme.Unknown || e.Theme == Theme.Resolve)
         {
             Logger.Info("theme switch requested with no target theme");
             return;

--- a/AutoDarkModeSvc/Events/SwitchEventArgs.cs
+++ b/AutoDarkModeSvc/Events/SwitchEventArgs.cs
@@ -73,7 +73,7 @@ public class SwitchEventArgs : EventArgs
     public bool RefreshDwm { get; } = false;
     public SwitchSource Source { get; }
     private List<ThemeOverrideSource> _themeOverrideSources { get; } = new();
-    public ReadOnlyCollection<ThemeOverrideSource> ThemeOverrideSources { get { return new(_themeOverrideSources); } }
-    public Theme Theme { get; private set; } = Theme.Automatic;
+    public ReadOnlyCollection<ThemeOverrideSource> ThemeOverrideSources { get => new(_themeOverrideSources); }
+    public Theme Theme { get; private set; } = Theme.Resolve;
     public DateTime? SwitchTime { get; private set; } = null;
 }

--- a/AutoDarkModeSvc/Governors/TimeSwitchGovernor.cs
+++ b/AutoDarkModeSvc/Governors/TimeSwitchGovernor.cs
@@ -58,7 +58,7 @@ internal class TimeSwitchGovernor : IAutoDarkModeGovernor
         if (!State.PostponeManager.IsPostponed)
         {
             if (init) init = false;
-            return new(isInSwitchWindow, new(SwitchSource.TimeSwitchModule, Theme.Automatic));
+            return new(isInSwitchWindow, new(SwitchSource.TimeSwitchModule, Theme.Resolve));
         }
         else
         {

--- a/AutoDarkModeSvc/Handlers/DwmRefreshHandler.cs
+++ b/AutoDarkModeSvc/Handlers/DwmRefreshHandler.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoDarkModeLib;
 using AutoDarkModeSvc.Events;
 using NLog;
 
@@ -15,7 +16,7 @@ internal sealed partial class DwmRefreshHandler
     private static readonly DwmRefreshHandler _instance = new();
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    private BlockingCollection<SwitchEventArgs> Queue { get; }
+    private BlockingCollection<DwmRefreshSource> Queue { get; }
     private Thread Worker { get; set; }
     private CancellationTokenSource Cancellation { get; } = new();
 
@@ -42,7 +43,7 @@ internal sealed partial class DwmRefreshHandler
         {
             try
             {
-                foreach (SwitchEventArgs e in Queue.GetConsumingEnumerable(Cancellation.Token))
+                foreach (DwmRefreshSource s in Queue.GetConsumingEnumerable(Cancellation.Token))
                 {
                     try
                     {
@@ -50,7 +51,7 @@ internal sealed partial class DwmRefreshHandler
                     }
                     catch (Exception ex)
                     {
-                        Logger.Warn(ex, "dwm management: refresh failed");
+                        Logger.Warn(ex, $"dwm management: refresh failed, source {Enum.GetName(s)}");
                     }
                 }
             }
@@ -68,10 +69,10 @@ internal sealed partial class DwmRefreshHandler
         Worker.Start();
     }
 
-    public static void Enqueue(SwitchEventArgs e)
+    public static void Enqueue(DwmRefreshSource source)
     {
         Logger.Debug("dwm management: enqueuing new dwm refresh");
-        _instance.Queue.Add(e);
+        _instance.Queue.Add(source);
     }
 
     public static void Shutdown()

--- a/AutoDarkModeSvc/Handlers/IThemeManager2/Tm2Handler.cs
+++ b/AutoDarkModeSvc/Handlers/IThemeManager2/Tm2Handler.cs
@@ -192,8 +192,7 @@ public static class Tm2Handler
         {
             flagList.ForEach(f =>
             {
-                // never allow color ignore flag to be set as this breaks win 11 theme switching
-                if (f != ThemeApplyFlags.IgnoreColor) flags |= f;
+                flags |= f;
             });
         }
 

--- a/AutoDarkModeSvc/Handlers/RegistryHandler.cs
+++ b/AutoDarkModeSvc/Handlers/RegistryHandler.cs
@@ -82,7 +82,7 @@ static class RegistryHandler
     /// Sets the taskbar color prevalence
     /// </summary>
     /// <param name="theme">0 for disabled, 1 for enabled</param>
-    public static void SetColorPrevalence(int theme)
+    public static void SetTaskbarColorPrevalence(int theme)
     {
         using RegistryKey key = GetPersonalizeKey();
         key.SetValue("ColorPrevalence", theme, RegistryValueKind.DWord);
@@ -92,7 +92,7 @@ static class RegistryHandler
     /// Checks if color prevalence is enabled
     /// </summary>
     /// <returns>true if enabled; false otherwise</returns>
-    public static bool IsColorPrevalence()
+    public static bool IsTaskbarColor()
     {
         using RegistryKey key = GetPersonalizeKey();
         var enabled = key.GetValue("ColorPrevalence").Equals(1);

--- a/AutoDarkModeSvc/Handlers/ThemeHandler.cs
+++ b/AutoDarkModeSvc/Handlers/ThemeHandler.cs
@@ -242,7 +242,7 @@ public static class ThemeHandler
                     return;
                 }
             }
-            DwmRefreshHandler.Enqueue(e);
+            DwmRefreshHandler.Enqueue(DwmRefreshSource.ThemeHandler);
         }
         else
         {

--- a/AutoDarkModeSvc/Service.cs
+++ b/AutoDarkModeSvc/Service.cs
@@ -92,7 +92,7 @@ class Service : Form
         ConfigMonitor.Start();
 
         // load pending postpone events
-        state.PostponeManager.GetPostonesFromDisk();
+        state.PostponeManager.GetPostponesFromDisk();
 
         ModuleTimer MainTimer = new(timerMillis, TimerName.Main);
         //ModuleTimer ShortTimer = new(TimerFrequency.Short, TimerName.Short);
@@ -186,7 +186,7 @@ class Service : Form
 
     private void TryFixTheme(object sender, EventArgs e)
     {
-        DwmRefreshHandler.Enqueue(new SwitchEventArgs(SwitchSource.Manual));
+        DwmRefreshHandler.Enqueue(DwmRefreshSource.User);
     }
 
     private void UpdateContextMenu(object sender, EventArgs e)

--- a/AutoDarkModeSvc/SwitchComponents/Base/AccentColorSwitch.cs
+++ b/AutoDarkModeSvc/SwitchComponents/Base/AccentColorSwitch.cs
@@ -26,10 +26,7 @@ class AccentColorSwitch : BaseComponent<SystemSwitchSettings>
 {
     public override bool ThemeHandlerCompatibility => true;
     public override DwmRefreshType NeedsDwmRefresh => DwmRefreshType.Standard;
-    public override bool Enabled
-    {
-        get { return Settings.Component.DWMPrevalenceSwitch; }
-    }
+    public override bool Enabled => Settings.Component.DWMPrevalenceSwitch;
 
     private bool currentDWMColorActive;
 

--- a/AutoDarkModeSvc/SwitchComponents/Base/SystemSwitch.cs
+++ b/AutoDarkModeSvc/SwitchComponents/Base/SystemSwitch.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Threading.Tasks;
 using AutoDarkModeLib;
+using AutoDarkModeLib.ComponentSettings.Base;
+using AutoDarkModeSvc.Events;
 using AutoDarkModeSvc.Handlers;
 
 namespace AutoDarkModeSvc.SwitchComponents.Base;
@@ -24,10 +26,117 @@ namespace AutoDarkModeSvc.SwitchComponents.Base;
 /// <summary>
 /// This class is a special case for the SwitchSystemThemeFile component, because on Windows builds older than 21H2 we use the legacy theme switching method
 /// </summary>
-class SystemSwitch : SystemSwitchThemeFile
+class SystemSwitch : BaseComponent<SystemSwitchSettings>
 {
+    protected Theme currentComponentTheme = Theme.Unknown;
+    protected bool themeModeEnabled;
+    protected bool currentTaskbarColorActive;
+    public override DwmRefreshType NeedsDwmRefresh => DwmRefreshType.Standard;
+    public SystemSwitch() : base() { }
+
+    protected override void EnableHook()
+    {
+        RefreshRegkeys();
+    }
+
+    protected void RefreshRegkeys()
+    {
+        try
+        {
+            currentComponentTheme = RegistryHandler.SystemUsesLightTheme() ? Theme.Light : Theme.Dark;
+            currentTaskbarColorActive = RegistryHandler.IsTaskbarColor();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "couldn't initialize system apps theme state");
+        }
+    }
+
     public override bool ThemeHandlerCompatibility { get; } = false;
-    protected override async Task SwitchSystemTheme(Theme newTheme)
+
+    protected override bool ComponentNeedsUpdate(SwitchEventArgs e)
+    {
+        if (Settings.Component.Mode == Mode.AccentOnly)
+        {
+            // if theme does not match dark we need to report true, as accent color isn't available in light mode
+            // Do not return true on windows theme mode, as this would potentially modify the theme
+            if (currentComponentTheme != Theme.Dark && !themeModeEnabled) return true;
+
+            if (e.Theme == Theme.Dark)
+            {
+                // allow toggling of the taskbar color in dark mode if it is not active yet, or still active
+                if (Settings.Component.TaskbarColorDuring == Theme.Dark && !currentTaskbarColorActive) return true;
+                else if (Settings.Component.TaskbarColorDuring == Theme.Light && currentTaskbarColorActive) return true;
+            }
+            else if (e.Theme == Theme.Light)
+            {
+                // allow toggling of the taskbar color in light mode if it is not active yet, or still active (inverse of Theme.Dark if clause)
+                if (Settings.Component.TaskbarColorDuring == Theme.Dark && currentTaskbarColorActive) return true;
+                else if (Settings.Component.TaskbarColorDuring == Theme.Light && !currentTaskbarColorActive) return true;
+            }
+            return false;
+        }
+        else if (Settings.Component.Mode == Mode.DarkOnly)
+        {
+            // Themes do not match
+            if (currentComponentTheme != Theme.Dark)
+            {
+                return true;
+            }
+            // Task bar accent color is disabled, but still active
+            else if (!Settings.Component.TaskbarColorSwitch && currentTaskbarColorActive)
+            {
+                return true;
+            }
+            // task bar accent color should switch, and taskbar color hasn't switched yet
+            else if (Settings.Component.TaskbarColorSwitch && !currentTaskbarColorActive)
+            {
+                return true;
+            }
+            return false;
+
+        }
+        else if (Settings.Component.Mode == Mode.LightOnly)
+        {
+            if (currentComponentTheme != Theme.Light)
+            {
+                return true;
+            }
+            return false;
+        }
+        else if (Settings.Component.Mode == Mode.Switch)
+        {
+            // Themes do not match
+            if (currentComponentTheme != e.Theme)
+            {
+                return true;
+            }
+            // Task bar accent color should switch, target is light mode and the taskbar color hasn't switched yet
+            else if (Settings.Component.TaskbarColorSwitch && currentTaskbarColorActive && e.Theme == Theme.Light)
+            {
+                return true;
+            }
+            // Task bar accent color is disabled, but still active
+            else if (!Settings.Component.TaskbarColorSwitch && currentTaskbarColorActive)
+            {
+                return true;
+            }
+            // task bar accent color should switch, target is dark mode and taskbar color hasn't switched yet
+            else if (Settings.Component.TaskbarColorSwitch && !currentTaskbarColorActive && e.Theme == Theme.Dark)
+            {
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    protected override void HandleSwitch(SwitchEventArgs e)
+    {
+        Task.Run(async () => { await SwitchSystemTheme(e.Theme); }).Wait();
+    }
+
+    protected async Task SwitchSystemTheme(Theme newTheme)
     {
         bool oldAccent = currentTaskbarColorActive;
         string oldTheme = Enum.GetName(typeof(Theme), currentComponentTheme);
@@ -59,11 +168,11 @@ class SystemSwitch : SystemSwitchThemeFile
         string accentInfo;
         if (Settings.Component.Mode == Mode.AccentOnly)
         {
-            accentInfo = $"on {Enum.GetName(typeof(Theme), Settings.Component.TaskbarColorWhenNonAdaptive).ToLower()}";
+            accentInfo = $"on {Enum.GetName(typeof(Theme), Settings.Component.TaskbarColorDuring).ToLower()}";
         }
         else
         {
-            accentInfo = Settings.Component.TaskbarColorOnAdaptive ? "yes" : "no";
+            accentInfo = Settings.Component.TaskbarColorSwitch ? "yes" : "no";
         }
         Logger.Info($"update info - previous: {oldTheme}/{(oldAccent ? "accent" : "NoAccent")}, " +
             $"now: {Enum.GetName(typeof(Theme), currentComponentTheme)}/{(currentTaskbarColorActive ? "Accent" : "NoAccent")}, " +
@@ -73,9 +182,9 @@ class SystemSwitch : SystemSwitchThemeFile
 
     private async Task SwitchLightOnly(int taskdelay)
     {
-        if (Settings.Component.TaskbarColorOnAdaptive)
+        if (Settings.Component.TaskbarColorSwitch)
         {
-            RegistryHandler.SetColorPrevalence(0);
+            RegistryHandler.SetTaskbarColorPrevalence(0);
             await Task.Delay(taskdelay);
         }
         currentTaskbarColorActive = false;
@@ -95,14 +204,14 @@ class SystemSwitch : SystemSwitchThemeFile
         }
         currentComponentTheme = Theme.Dark;
         await Task.Delay(taskdelay);
-        if (Settings.Component.TaskbarColorOnAdaptive)
+        if (Settings.Component.TaskbarColorSwitch)
         {
-            RegistryHandler.SetColorPrevalence(1);
+            RegistryHandler.SetTaskbarColorPrevalence(1);
             currentTaskbarColorActive = true;
         }
-        else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
+        else if (!Settings.Component.TaskbarColorSwitch && currentTaskbarColorActive)
         {
-            RegistryHandler.SetColorPrevalence(0);
+            RegistryHandler.SetTaskbarColorPrevalence(0);
             currentTaskbarColorActive = false;
         }
     }
@@ -111,7 +220,7 @@ class SystemSwitch : SystemSwitchThemeFile
     {
         if (newTheme == Theme.Light)
         {
-            RegistryHandler.SetColorPrevalence(0);
+            RegistryHandler.SetTaskbarColorPrevalence(0);
             currentTaskbarColorActive = false;
             await Task.Delay(taskdelay);
             RegistryHandler.SetSystemTheme((int)newTheme);
@@ -128,17 +237,58 @@ class SystemSwitch : SystemSwitchThemeFile
             }
             currentComponentTheme = Theme.Dark;
             await Task.Delay(taskdelay);
-            if (Settings.Component.TaskbarColorOnAdaptive)
+            if (Settings.Component.TaskbarColorSwitch)
             {
-                RegistryHandler.SetColorPrevalence(1);
+                RegistryHandler.SetTaskbarColorPrevalence(1);
                 currentTaskbarColorActive = true;
             }
-            else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
+            else if (!Settings.Component.TaskbarColorSwitch && currentTaskbarColorActive)
             {
-                RegistryHandler.SetColorPrevalence(0);
+                RegistryHandler.SetTaskbarColorPrevalence(0);
                 currentTaskbarColorActive = false;
             }
         }
         currentComponentTheme = newTheme;
+    }
+
+    protected async Task SwitchAccentOnly(Theme newTheme, int taskdelay)
+    {
+        if (currentComponentTheme != Theme.Dark && !themeModeEnabled)
+        {
+            RegistryHandler.SetSystemTheme((int)Theme.Dark);
+        }
+        else
+        {
+            taskdelay = 0;
+        }
+        await Task.Delay(taskdelay);
+
+        if (newTheme == Theme.Dark)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Dark)
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(1);
+                currentTaskbarColorActive = true;
+            }
+            else
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(0);
+                currentTaskbarColorActive = false;
+            }
+        }
+        else if (newTheme == Theme.Light)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Light)
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(1);
+                currentTaskbarColorActive = true;
+            }
+            else
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(0);
+                currentTaskbarColorActive = false;
+            }
+        }
+        currentComponentTheme = Theme.Dark;
     }
 }

--- a/AutoDarkModeSvc/SwitchComponents/Base/SystemSwitchThemeFile.cs
+++ b/AutoDarkModeSvc/SwitchComponents/Base/SystemSwitchThemeFile.cs
@@ -37,61 +37,26 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
         RefreshRegkeys();
     }
 
+
     protected void RefreshRegkeys()
     {
         try
         {
             currentComponentTheme = RegistryHandler.SystemUsesLightTheme() ? Theme.Light : Theme.Dark;
-            currentTaskbarColorActive = RegistryHandler.IsColorPrevalence();
         }
         catch (Exception ex)
         {
             Logger.Error(ex, "couldn't initialize system apps theme state");
         }
     }
-    public override bool ThemeHandlerCompatibility => true;
+    public override bool ThemeHandlerCompatibility => false;
 
     protected override bool ComponentNeedsUpdate(SwitchEventArgs e)
     {
-        if (Settings.Component.Mode == Mode.AccentOnly)
-        {
-            // if theme does not match dark we need to report true, as accent color isn't available in light mode
-            // Do not return true on windows theme mode, as this would potentially modify the theme
-            if (currentComponentTheme != Theme.Dark && !themeModeEnabled) return true;
-
-            if (e.Theme == Theme.Dark)
-            {
-                // allow toggling of the taskbar color in dark mode if it is not active yet, or still active
-                if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Dark && !currentTaskbarColorActive) return true;
-                else if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Light && currentTaskbarColorActive) return true;
-            }
-            else if (e.Theme == Theme.Light)
-            {
-                // allow toggling of the taskbar color in light mode if it is not active yet, or still active (inverse of Theme.Dark if clause)
-                if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Dark && currentTaskbarColorActive) return true;
-                else if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Light && !currentTaskbarColorActive) return true;
-            }
-            return false;
-        }
-
-        if (themeModeEnabled)
-        {
-            return false;
-        }
-        else if (Settings.Component.Mode == Mode.DarkOnly)
+        if (Settings.Component.Mode == Mode.DarkOnly)
         {
             // Themes do not match
             if (currentComponentTheme != Theme.Dark)
-            {
-                return true;
-            }
-            // Task bar accent color is disabled, but still active
-            else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
-            {
-                return true;
-            }
-            // task bar accent color should switch, and taskbar color hasn't switched yet
-            else if (Settings.Component.TaskbarColorOnAdaptive && !currentTaskbarColorActive)
             {
                 return true;
             }
@@ -113,21 +78,6 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
             {
                 return true;
             }
-            // Task bar accent color should switch, target is light mode and the taskbar color hasn't switched yet
-            else if (Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive && e.Theme == Theme.Light)
-            {
-                return true;
-            }
-            // Task bar accent color is disabled, but still active
-            else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
-            {
-                return true;
-            }
-            // task bar accent color should switch, target is dark mode and taskbar color hasn't switched yet
-            else if (Settings.Component.TaskbarColorOnAdaptive && !currentTaskbarColorActive && e.Theme == Theme.Dark)
-            {
-                return true;
-            }
             return false;
         }
         return false;
@@ -135,22 +85,16 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
 
     protected override void HandleSwitch(SwitchEventArgs e)
     {
-        Task.Run(async () => { await SwitchSystemTheme(e.Theme); }).Wait();
+        SwitchSystemTheme(e.Theme);
     }
 
-    protected async virtual Task SwitchSystemTheme(Theme newTheme)
+    protected virtual void SwitchSystemTheme(Theme newTheme)
     {
         bool oldAccent = currentTaskbarColorActive;
         string oldTheme = Enum.GetName(typeof(Theme), currentComponentTheme);
-        int taskdelay = Settings.Component.TaskbarSwitchDelay;
         try
         {
-            // Set system theme
-            if (Settings.Component.Mode == Mode.AccentOnly)
-            {
-                await SwitchAccentOnly(newTheme, taskdelay);
-            }
-            else if (Settings.Component.Mode == Mode.LightOnly)
+            if (Settings.Component.Mode == Mode.LightOnly)
             {
                 SwitchLightOnly();
             }
@@ -170,11 +114,11 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
         string accentInfo;
         if (Settings.Component.Mode == Mode.AccentOnly)
         {
-            accentInfo = $"on {Enum.GetName(typeof(Theme), Settings.Component.TaskbarColorWhenNonAdaptive).ToLower()}";
+            accentInfo = $"on {Enum.GetName(typeof(Theme), Settings.Component.TaskbarColorDuring).ToLower()}";
         }
         else
         {
-            accentInfo = Settings.Component.TaskbarColorOnAdaptive ? "yes" : "no";
+            accentInfo = Settings.Component.TaskbarColorSwitch ? "yes" : "no";
         }
         Logger.Info($"update info - previous: {oldTheme}/{(oldAccent ? "Accent" : "NoAccent")}, " +
             $"pending: {Enum.GetName(typeof(Theme), currentComponentTheme)}/{(currentTaskbarColorActive ? "Accent" : "NoAccent")}, " +
@@ -182,56 +126,14 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
             $"accent: {accentInfo}");
     }
 
-    protected async Task SwitchAccentOnly(Theme newTheme, int taskdelay)
-    {
-        if (currentComponentTheme != Theme.Dark && !themeModeEnabled)
-        {
-            RegistryHandler.SetSystemTheme((int)Theme.Dark);
-        }
-        else
-        {
-            taskdelay = 0;
-        }
-        await Task.Delay(taskdelay);
-
-        if (newTheme == Theme.Dark)
-        {
-            if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Dark)
-            {
-                RegistryHandler.SetColorPrevalence(1);
-                currentTaskbarColorActive = true;
-            }
-            else
-            {
-                RegistryHandler.SetColorPrevalence(0);
-                currentTaskbarColorActive = false;
-            }
-        }
-        else if (newTheme == Theme.Light)
-        {
-            if (Settings.Component.TaskbarColorWhenNonAdaptive == Theme.Light)
-            {
-                RegistryHandler.SetColorPrevalence(1);
-                currentTaskbarColorActive = true;
-            }
-            else
-            {
-                RegistryHandler.SetColorPrevalence(0);
-                currentTaskbarColorActive = false;
-            }
-        }
-        currentComponentTheme = Theme.Dark;
-    }
-
     protected void SwitchLightOnly()
     {
-        if (Settings.Component.TaskbarColorOnAdaptive)
+
+        if (currentComponentTheme != Theme.Dark)
         {
-            RegistryHandler.SetColorPrevalence(0);
+            ThemeFile themeFile = GlobalState.ManagedThemeFile;
+            themeFile.VisualStyles.SystemMode = (nameof(Theme.Light), themeFile.VisualStyles.SystemMode.Item2);
         }
-        currentTaskbarColorActive = false;
-        ThemeFile themeFile = GlobalState.ManagedThemeFile;
-        themeFile.VisualStyles.SystemMode = (nameof(Theme.Light), themeFile.VisualStyles.SystemMode.Item2);
         currentComponentTheme = Theme.Light;
     }
 
@@ -243,16 +145,6 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
             themeFile.VisualStyles.SystemMode = (nameof(Theme.Dark), themeFile.VisualStyles.SystemMode.Item2);
         }
         currentComponentTheme = Theme.Dark;
-        if (Settings.Component.TaskbarColorOnAdaptive)
-        {
-            RegistryHandler.SetColorPrevalence(1);
-            currentTaskbarColorActive = true;
-        }
-        else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
-        {
-            RegistryHandler.SetColorPrevalence(0);
-            currentTaskbarColorActive = false;
-        }
     }
 
     protected void SwitchAdaptive(Theme newTheme)
@@ -260,27 +152,11 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
         ThemeFile themeFile = GlobalState.ManagedThemeFile;
         if (newTheme == Theme.Light)
         {
-            RegistryHandler.SetColorPrevalence(0);
-            currentTaskbarColorActive = false;
             themeFile.VisualStyles.SystemMode = (nameof(Theme.Light), themeFile.VisualStyles.SystemMode.Item2);
         }
         else if (newTheme == Theme.Dark)
         {
-            if (currentComponentTheme != Theme.Dark)
-            {
-                themeFile.VisualStyles.SystemMode = (nameof(Theme.Dark), themeFile.VisualStyles.SystemMode.Item2);
-            }
-            currentComponentTheme = Theme.Dark;
-            if (Settings.Component.TaskbarColorOnAdaptive)
-            {
-                RegistryHandler.SetColorPrevalence(1);
-                currentTaskbarColorActive = true;
-            }
-            else if (!Settings.Component.TaskbarColorOnAdaptive && currentTaskbarColorActive)
-            {
-                RegistryHandler.SetColorPrevalence(0);
-                currentTaskbarColorActive = false;
-            }
+            themeFile.VisualStyles.SystemMode = (nameof(Theme.Dark), themeFile.VisualStyles.SystemMode.Item2);
         }
         currentComponentTheme = newTheme;
     }
@@ -291,4 +167,6 @@ class SystemSwitchThemeFile : BaseComponent<SystemSwitchSettings>
         themeModeEnabled = builder.Config.WindowsThemeMode.Enabled;
         RefreshRegkeys();
     }
+
+
 }

--- a/AutoDarkModeSvc/SwitchComponents/Base/TaskbarColorSwitch.cs
+++ b/AutoDarkModeSvc/SwitchComponents/Base/TaskbarColorSwitch.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoDarkModeLib;
+using AutoDarkModeLib.ComponentSettings.Base;
+using AutoDarkModeSvc.Events;
+using AutoDarkModeSvc.Handlers;
+using NLog;
+
+namespace AutoDarkModeSvc.SwitchComponents.Base;
+internal class TaskbarColorSwitch : BaseComponent<SystemSwitchSettings>
+{
+    public override bool ThemeHandlerCompatibility => true;
+    public override DwmRefreshType NeedsDwmRefresh => DwmRefreshType.Standard;
+    public override bool Enabled => Settings.Component.TaskbarColorSwitch;
+
+    private bool currentTaskbarColorActive;
+
+    public TaskbarColorSwitch() : base() { }
+
+    protected override void EnableHook()
+    {
+        try
+        {
+            currentTaskbarColorActive = RegistryHandler.IsTaskbarColor();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "couldn't retrieve DWM prevalence state: ");
+        }
+    }
+
+    protected override bool ComponentNeedsUpdate(SwitchEventArgs e)
+    {
+        if (e.Theme == Theme.Dark)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Dark && !currentTaskbarColorActive)
+            {
+                return true;
+            }
+            else if (Settings.Component.DWMPrevalenceEnableTheme == Theme.Light && currentTaskbarColorActive)
+            {
+                return true;
+            }
+        }
+        else if (e.Theme == Theme.Light)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Light && !currentTaskbarColorActive)
+            {
+                return true;
+            }
+            else if (Settings.Component.TaskbarColorDuring == Theme.Dark && currentTaskbarColorActive)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected override void HandleSwitch(SwitchEventArgs e)
+    {
+        if (e.Theme == Theme.Dark)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Dark)
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(1);
+                currentTaskbarColorActive = true;
+            }
+            else
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(0);
+                currentTaskbarColorActive = false;
+            }
+        }
+        else if (e.Theme == Theme.Light)
+        {
+            if (Settings.Component.TaskbarColorDuring == Theme.Light)
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(1);
+                currentTaskbarColorActive = true;
+            }
+            else
+            {
+                RegistryHandler.SetTaskbarColorPrevalence(0);
+                currentTaskbarColorActive = false;
+            }
+        }
+    }
+
+    protected override void DisableHook()
+    {
+        if (RegistryHandler.SystemUsesLightTheme() && currentTaskbarColorActive)
+        {
+            RegistryHandler.SetTaskbarColorPrevalence(0);
+            DwmRefreshHandler.Enqueue(DwmRefreshSource.TaskbarColorSwitchComponent);
+        }
+    }
+}


### PR DESCRIPTION
Since we can now handle window refreshes, ignoring the colorization color on Windows theme mode switches became possible.

This PR removes the limitation from our theme switching engine and adds the respective option to the frontend.