### PR TITLE
Create settings card for accent modes

### DIFF
--- a/AutoDarkModeApp/Strings/ar/Resources.resw
+++ b/AutoDarkModeApp/Strings/ar/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>لون مميز</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>لون التمييز لشريط المهام</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>فقط التمييز</value>
   </data>
@@ -297,9 +294,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>لا تقم بتبديل النسق إلا إذا كان النظام خاملاً</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>لون مميز لأشرطة العناوين وحدود النوافذ فقط أثناء</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>إيدج (الإصدار القديم)</value>
@@ -978,5 +972,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color on the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/cs/Resources.resw
+++ b/AutoDarkModeApp/Strings/cs/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Kontrastní barva</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Zvýraznění barev hlavního panelu</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Pouze barva</value>
   </data>
@@ -298,9 +295,6 @@ Jestli se Vám moje aplikace líbí, zvažte, zda byste mne nechtěli podpořit.
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Neměnit motivy pokud systém není v nečinnosti</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Kontrastní barvy pro titulní pruhy a hranice okna pouze během</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (stará verze)</value>
@@ -981,5 +975,17 @@ Nainstalovaná verze: {0}, nová verze: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/de/Resources.resw
+++ b/AutoDarkModeApp/Strings/de/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Akzentfarbe</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Akzentfarbe für die Taskleiste</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Nur Akzentfarbe</value>
   </data>
@@ -298,9 +295,6 @@ Aus diesem Grund hast du die Möglichkeit, mir eine kleine Spende dazulassen. Se
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Kein Designwechsel, wenn das System beschäftigt ist</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Akzentfarbe für Titelleisten und Fensterrahmen nur während</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (alte Version)</value>
@@ -981,5 +975,17 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Farbe ignorieren</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/el-gr/Resources.resw
+++ b/AutoDarkModeApp/Strings/el-gr/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Χρώμα έμφασης</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Χρώμα έμφασης στη γραμμή εργασιών</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Μόνο χρώμα έμφασης</value>
   </data>
@@ -297,9 +294,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Να μην γίνεται εναλλαγή θεμάτων εκτός εάν το σύστημά είναι σε αδράνεια</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Χρώμα έμφασης για γραμμές τίτλου και περιγράμματα παραθύρων μόνο όταν εφαρμόζεται</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (παλιά μέθοδος)</value>
@@ -975,5 +969,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Accent color</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Accent Color for Taskbar</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Accent only</value>
   </data>
@@ -299,9 +296,6 @@ For this reason you could support me with a voluntary donation. Even a small amo
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Don't switch themes unless the system is idle</value>
     <comment>Please don't use a double-negative, it's confusing</comment>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Accent Color for title bars and window borders only during</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Legacy)</value>
@@ -972,5 +966,17 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/es/Resources.resw
+++ b/AutoDarkModeApp/Strings/es/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Acentuar el color</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Color de acento para la barra de tareas</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Solo acento</value>
   </data>
@@ -298,9 +295,6 @@ Por este motivo puedes apoyarme con una donación voluntaria. Incluso una peque�
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>No cambiar temas salvo que el sistema esté en reposo</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Color de acento para las barras de título y los bordes de las ventanas solo durante</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (versión antigua)</value>
@@ -981,5 +975,17 @@ Versión instalada actualmente: {0}, nueva versión: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Accent color</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>رنگ تأکیدی برای نوار وظیفه</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Accent only</value>
   </data>
@@ -298,9 +295,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Don't switch themes unless the system is idle</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Accent Color for title bars and window borders only during</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>گوشه (قدیمی)</value>
@@ -981,5 +975,17 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fr/Resources.resw
+++ b/AutoDarkModeApp/Strings/fr/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Couleur d'accentuation</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Couleur d'accentuation pour la barre des tâches</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Couleur d'accentuation uniquement</value>
   </data>
@@ -298,9 +295,6 @@ C'est pourquoi vous pouvez me soutenir avec un don libre. Même un petit montant
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Ne pas changer de thème à moins que le système ne soit inactif</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Couleur d'accentuation de la barre de titre et des contours de la fenêtre seulement pendant</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (ancienne version)</value>
@@ -981,5 +975,17 @@ Version installée : {0}, nouvelle version : {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/he/Resources.resw
+++ b/AutoDarkModeApp/Strings/he/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Accent color</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Accent Color for Taskbar</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Accent only</value>
   </data>
@@ -298,9 +295,6 @@ For this reason you could support me with a voluntary donation. Even a small amo
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Don't switch themes unless the system is idle</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Accent Color for title bars and window borders only during</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>گوشه (قدیمی)</value>
@@ -981,5 +975,17 @@ Click "Yes" to open a new browser window.
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Kiemelőszín</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Kiemelő szín a tálcához</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Csak Kiemelőszín</value>
   </data>
@@ -298,9 +295,6 @@ Ebből kifolyólag támogathatna egy önkéntes adománnyal. Még egy kis össze
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Csak akkor váltson témát, ha a rendszer tétlen</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Kiemelő szín csak a címsorok és az ablakszegélyek számára a következő időszakban</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Régi)</value>
@@ -981,5 +975,17 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/id/Resources.resw
+++ b/AutoDarkModeApp/Strings/id/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Aksen warna</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Aksen warna untuk bilah tugas</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Dengan aksen</value>
   </data>
@@ -298,9 +295,6 @@ Karena itu Anda dapat memberi sumbangan secara sukarela. Sumbangan kecil bahkan 
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Jangan beralih tema kecuali sistem menganggur</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Aksen warna untuk bilah judul dan batas jendela hanya dalam</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (versi lama)</value>
@@ -981,5 +975,17 @@ Versi saat ini: {0}, Versi terbaru: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/it/Resources.resw
+++ b/AutoDarkModeApp/Strings/it/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Colore principale</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Colore principale per la barra delle applicazioni</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Solo il colore principale</value>
   </data>
@@ -298,9 +295,6 @@ Per questo motivo, ti chiederei di supportarmi con una donazione volontaria, anc
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Non cambiare tema finché il sistema è inattivo</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Colore principale per le barre del titolo e i bordi delle finestre solo durante</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (vecchia versione)</value>
@@ -981,5 +975,17 @@ Versione attualmente installata: {0}, nuova versione: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ja/Resources.resw
+++ b/AutoDarkModeApp/Strings/ja/Resources.resw
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -125,9 +125,6 @@
   </data>
   <data name="AccentColor" xml:space="preserve">
     <value>アクセントカラー</value>
-  </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>タスクバーのアクセントカラー</value>
   </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>アクセントカラーのみ</value>
@@ -298,9 +295,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>システムがアイドル状態でないならテーマを切り替えない</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>タイトルバーとウィンドウの境界線のアクセントカラー</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (旧バージョン用)</value>
@@ -741,6 +735,9 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="SelectLightCursor" xml:space="preserve">
     <value>ライト用のカーソルを選択</value>
   </data>
+  <data name="Set" xml:space="preserve">
+    <value>Set</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>設定</value>
   </data>
@@ -888,11 +885,17 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
     <value>Background</value>
     <comment>match Windows Settings</comment>
   </data>
+  <data name="SelectColor" xml:space="preserve">
+    <value>色を選択</value>
+  </data>
   <data name="DisableWindowsManagesTheme" xml:space="preserve">
     <value>Disable Windows manages your theme</value>
   </data>
   <data name="Path" xml:space="preserve">
     <value>Path</value>
+  </data>
+  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
+    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
   </data>
   <data name="Beta" xml:space="preserve">
     <value>ベータ版</value>
@@ -906,20 +909,11 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="Language" xml:space="preserve">
     <value>言語</value>
   </data>
-  <data name="Stable" xml:space="preserve">
-    <value>安定版</value>
-  </data>
-  <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
-  </data>
-  <data name="Set" xml:space="preserve">
-    <value>Set</value>
-  </data>
-  <data name="SelectColor" xml:space="preserve">
-    <value>色を選択</value>
-  </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
     <value>Windows スポットライトの設定を開く</value>
+  </data>
+  <data name="Stable" xml:space="preserve">
+    <value>安定版</value>
   </data>
   <data name="Switch" xml:space="preserve">
     <value>切り替え</value>
@@ -971,5 +965,17 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ko/Resources.resw
+++ b/AutoDarkModeApp/Strings/ko/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>강조 색상</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>작업 표시줄의 강조 색상</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>강조만</value>
   </data>
@@ -298,9 +295,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>시스템이 유휴 상태가 아니면 테마 전환 안 함</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>제목 표시줄 및 창 테두리에 대한 강조 색상은 다음 기간 동안만 사용됩니다</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (기존)</value>
@@ -981,5 +975,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nb-no/Resources.resw
+++ b/AutoDarkModeApp/Strings/nb-no/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Aksentfarge</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Aksentfarge for oppgavelinje</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Kun aksent</value>
   </data>
@@ -298,9 +295,6 @@ For this reason you could support me with a voluntary donation. Even a small amo
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Ikke bytt tema, med mindre systemet er inaktivt</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Aksentfarger for tittellinjer og vinduskanter kun når</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Legacy):</value>
@@ -981,5 +975,17 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nl/Resources.resw
+++ b/AutoDarkModeApp/Strings/nl/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Accentkleur</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Accentkleur voor taakbalk</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Alleen accentkleur</value>
   </data>
@@ -298,9 +295,6 @@ Hierom zou u mij kunnen steunen met een vrijwillige donatie. Zelfs een klein bed
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Niet van thema wisselen tenzij het systeem inactief is</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Accentkleur voor titelbalken en vensterranden alleen bij</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (oud)</value>
@@ -981,5 +975,17 @@ Momenteel geïnstalleerde versie: {0}, nieuwe versie: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pl/Resources.resw
+++ b/AutoDarkModeApp/Strings/pl/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Kolor akcentu</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Kolor paska zadań</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Tylko kolor paska zadań</value>
   </data>
@@ -298,9 +295,6 @@ Jeżeli chcesz, możesz wesprzeć mnie dobrowolną darowizną. Nawet najmniejsza
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Nie przełączaj, jeśli system jest zajęty</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Kolor akcentu dla pasków tytułu i ramek okien dla motywu</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (starsza wersja)</value>
@@ -981,5 +975,17 @@ Obecnie zainstalowana wersja: {0}, nowa wersja: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-br/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-br/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Cor de destaque</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Cor de destaque para a barra de tarefas</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Destaque apenas</value>
   </data>
@@ -298,9 +295,6 @@ Por esta razão, você pode me apoiar com uma doação voluntária. Até uma peq
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Não altere os temas a menos que o sistema esteja parado</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Cor de destaque para barras de título e bordas de janela somente durante</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (versão antiga)</value>
@@ -981,5 +975,17 @@ Versão instalada atualmente: {0}, nova versão: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-pt/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-pt/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Cor do Destaque</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Cor de destaque na Barra de Tarefas</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Destaque apenas</value>
   </data>
@@ -298,9 +295,6 @@ Por esta razão pode suportar-me com uma doação voluntária. Até uma pequena 
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Não mudar temas a não ser que o sistema não esteja a fazer nada</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Cor de Destaque para barras de título e bordas da janela apenas durante</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (versão Legacy)</value>
@@ -981,5 +975,17 @@ Versão instalada: {0}, Versão nova: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ro/Resources.resw
+++ b/AutoDarkModeApp/Strings/ro/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Nuanță culoare</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Culoare de accent pentru bara de activități</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Numai accent</value>
   </data>
@@ -298,9 +295,6 @@ Din acest motiv ai putea sa ma sustii cu o donatie voluntara. Chiar și o cantit
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Nu schimbați teme decât dacă sistemul este inactiv</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Culoarea accent pentru bara de titlu și pentru conturul ferestrelor numai în timpul</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Versiune veche)</value>
@@ -981,5 +975,17 @@ Versiunea instalată în prezent: {0}, versiune nouă: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ru/Resources.resw
+++ b/AutoDarkModeApp/Strings/ru/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Акцентный цвет</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Использовать акцентный цвет для панели задач</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Только акцентный цвет</value>
   </data>
@@ -298,9 +295,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Не переключать темы, пока система не бездействует</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Использовать акцентный цвет для заголовков и границ окон только во время</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (старая версия)</value>
@@ -981,5 +975,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sr/Resources.resw
+++ b/AutoDarkModeApp/Strings/sr/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Boja naglašavanja</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Boja naglašavanja na traci zadataka</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Samo naglašavanje</value>
   </data>
@@ -298,9 +295,6 @@ Zato bi bilo baš lepo od vas da me podržite donacijom. Čak i mala količina j
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Ne menjaj teme ako sistem nije neaktivan</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Boja naglašavanja na naslovnoj traci i ivicama prozora samo tokom</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (zastareli)</value>
@@ -981,5 +975,17 @@ Trenutno instalirana verzija: {0}, nova verzija: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sv/Resources.resw
+++ b/AutoDarkModeApp/Strings/sv/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Accent color</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Accentfärg för Aktivitetsfältet</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Accent only</value>
   </data>
@@ -298,9 +295,6 @@ For this reason you could support me with a voluntary donation. Even a small amo
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Don't switch themes unless the system is idle</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Accent Color for title bars and window borders only during</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Legacy)</value>
@@ -981,5 +975,17 @@ Installerad version: {0}, ny version: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/tr/Resources.resw
+++ b/AutoDarkModeApp/Strings/tr/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Vurgu rengi</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Görev çubuğu için vurgu rengi</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Sadece vurgu</value>
   </data>
@@ -298,9 +295,6 @@ Bu nedenle bana gönüllü bir bağışla destek olabilirsiniz. Küçük bir mik
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Sistem boşta olmadığı sürece temaları değiştirme</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Yalnızca temadayken başlık çubukları ve pencere kenarlıkları için Vurgu Rengi</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Eski)</value>
@@ -981,5 +975,17 @@ Bunu indirmek istiyor musunuz?
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/uk/Resources.resw
+++ b/AutoDarkModeApp/Strings/uk/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Акцентний колір</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Колір для панелі задач</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Тільки акцент</value>
   </data>
@@ -297,9 +294,6 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Не перемикати теми якщо система не в режимі очікування</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Колір акценту для рядків заголовків і меж вікон тільки під час</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (застарілий)</value>
@@ -975,5 +969,17 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/vi/Resources.resw
+++ b/AutoDarkModeApp/Strings/vi/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>Màu nhấn</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>Màu nhấn cho Thanh tác vụ</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>Chỉ màu nhấn</value>
   </data>
@@ -298,9 +295,6 @@ Vì lý do đó, bạn có thể ủng hộ tôi bằng một khoản đóng gó
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>Không chuyển chủ đề trừ khi hệ thống đang nghỉ</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>Màu nhấn cho thanh tiêu đề và viền cửa sổ chỉ trong khi</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge (Phiên bản cũ)</value>
@@ -981,5 +975,17 @@ Phiên bản hiện tại của bạn: {0}, phiên bản mới: {1}</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hans/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hans/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>主题色</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>使用主题色作为任务栏颜色</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>仅主题色</value>
   </data>
@@ -297,9 +294,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>系统非空闲状态时不进行切换</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>仅当使用所选主题时，将相应的主题色应用到标题栏和窗口边框</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge（旧版）</value>
@@ -965,5 +959,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -126,9 +126,6 @@
   <data name="AccentColor" xml:space="preserve">
     <value>輔色</value>
   </data>
-  <data name="AccentColorForTaskbar" xml:space="preserve">
-    <value>工作列輔色</value>
-  </data>
   <data name="AccentOnly" xml:space="preserve">
     <value>僅輔色</value>
   </data>
@@ -298,9 +295,6 @@
   </data>
   <data name="DonotSwitchIdleTimer" xml:space="preserve">
     <value>僅在系統處於空閒狀態時切換主題</value>
-  </data>
-  <data name="DWMPrevalence" xml:space="preserve">
-    <value>僅在使用所選主題時，套用相對應的輔色到標題列與視窗邊框</value>
   </data>
   <data name="Edge" xml:space="preserve">
     <value>Edge（舊版）</value>
@@ -981,5 +975,17 @@
   </data>
   <data name="IgnoreColor" xml:space="preserve">
     <value>Ignore color</value>
+  </data>
+  <data name="AccentSurfaces" xml:space="preserve">
+    <value>Accent Surfaces</value>
+  </data>
+  <data name="AccentApplyTaskbar" xml:space="preserve">
+    <value>Apply accent color to the taskbar</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Apply accent color on title bars and window borders</value>
+  </data>
+  <data name="AccentSurfacesChoose" xml:space="preserve">
+    <value>Choose when the accent color should be applied</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -28,29 +28,35 @@
                         <ComboBoxItem Content="{helpers:ResourceString Name=Disabled}" />
                     </ComboBox>
                 </controls:SettingsCard>
+                
 
                 <!--  Windows mode  -->
-                <controls:SettingsExpander Header="{helpers:ResourceString Name=WindowsMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE770;}">
+                <controls:SettingsCard Header="{helpers:ResourceString Name=WindowsMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE770;}">
                     <ComboBox SelectedIndex="{x:Bind ViewModel.SystemSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
                         <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysDark}" />
                         <ComboBoxItem Content="{helpers:ResourceString Name=Disabled}" />
                     </ComboBox>
+                </controls:SettingsCard>
 
+                <!--  Accent Mode  -->
+                <controls:SettingsExpander Header="{helpers:ResourceString Name=AccentSurfaces}"
+                                           Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
+                                       HeaderIcon="{ui:FontIcon Glyph=&#xE790;}">
                     <controls:SettingsExpander.Items>
                         <controls:SettingsCard>
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
-                                    <CheckBox
-                                        x:Name="AdaptiveTaskbarAccentCheckBox"
-                                        Content="{helpers:ResourceString Name=AdaptiveTaskbarAccent}"
-                                              IsChecked="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}"/>
+                                    <CheckBox x:Name="AdaptiveTaskbarAccentCheckBox"
+                                              Content="{helpers:ResourceString Name=AccentApplyTaskbar}"
+                                              IsChecked="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
 
                                     <RadioButtons IsEnabled="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=OneWay}">
                                         <RadioButton Content="{helpers:ResourceString Name=LightTheme}"
-                                                     IsEnabled="{x:Bind ViewModel.LightTaskbarAccentPermitted}" IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnLight, Mode=TwoWay}" />
-                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnDark, Mode=TwoWay}" />
+                                                     IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnLight, Mode=TwoWay}" />
+                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}"
+                                                     IsChecked="{x:Bind ViewModel.IsTaskbarAccentOnDark, Mode=TwoWay}" />
                                     </RadioButtons>
                                 </StackPanel>
                             </controls:SettingsCard.Header>
@@ -58,14 +64,15 @@
                         <controls:SettingsCard>
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
-                                    <CheckBox
-                                        x:Name="DWMPrevalenceSwitcCheckBox"
-                                        Content="{helpers:ResourceString Name=DWMPrevalence}"
-                                        IsChecked="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
+                                    <CheckBox x:Name="DWMPrevalenceSwitcCheckBox"
+                                              Content="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
+                                              IsChecked="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
 
                                     <RadioButtons IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
-                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
-                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeDark, Mode=TwoWay}" />
+                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}"
+                                                     IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
+                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}"
+                                                     IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeDark, Mode=TwoWay}" />
                                     </RadioButtons>
                                 </StackPanel>
                             </controls:SettingsCard.Header>


### PR DESCRIPTION
## Description

Far from done yet, but it at least moves the accent color settings away from the system modes, which is a start.
Still not sure how to handle the checkbox / radiobutton combo.

I think maybe turning the checkbox into a toggle would be okay, and then we move the "Choose when the accent color should be applied" description as a header for the "Light Theme" and "Dark Theme" radio buttons?

I don't know enough about winui3 to make this happen in a Microsoft-canonical way, so I'm gonna merge this in and then you can be free to modify as you see fit.

## Image

<img width="1374" height="1058" alt="image" src="https://github.com/user-attachments/assets/ff4f459b-1581-47de-ac90-acb032ded060" />
