### PR TITLE
Fix: Configuration watcher isn't working properly

### DIFF
--- a/AutoDarkModeApp/ViewModels/TimeViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/TimeViewModel.cs
@@ -304,9 +304,9 @@ public partial class TimeViewModel : ObservableRecipient
         _isInitializing = false;
     }
 
-    private void SafeApplyTheme()
+    private static async void SafeApplyTheme()
     {
-        _dispatcherQueue.TryEnqueue(async () => await MessageHandler.Client.SendMessageAndGetReplyAsync(Command.RequestSwitch, 15));
+        await MessageHandler.Client.SendMessageAndGetReplyAsync(Command.RequestSwitch, 15);
     }
 
     private void HandleConfigUpdate()
@@ -468,6 +468,7 @@ public partial class TimeViewModel : ObservableRecipient
         {
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "TimeViewModel");
         }
+
         SafeApplyTheme();
     }
 


### PR DESCRIPTION
### Description

The reason for this Bug is b2bd150.

The ConfigWatcher property creates a new instance each time it is accessed. The event was added to a different FileSystemWatcher instance.

Closes: #1054 #1055 #1056