### PR TITLE
Regroup System Area Configuration Items Pt2

### DIFF
--- a/AutoDarkModeApp/Strings/ar/Resources.resw
+++ b/AutoDarkModeApp/Strings/ar/Resources.resw
@@ -979,10 +979,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/cs/Resources.resw
+++ b/AutoDarkModeApp/Strings/cs/Resources.resw
@@ -982,10 +982,13 @@ Nainstalovaná verze: {0}, nová verze: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/de/Resources.resw
+++ b/AutoDarkModeApp/Strings/de/Resources.resw
@@ -982,10 +982,13 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/el-gr/Resources.resw
+++ b/AutoDarkModeApp/Strings/el-gr/Resources.resw
@@ -976,10 +976,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -973,10 +973,13 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/es/Resources.resw
+++ b/AutoDarkModeApp/Strings/es/Resources.resw
@@ -982,10 +982,13 @@ Versión instalada actualmente: {0}, nueva versión: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -982,10 +982,13 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/fr/Resources.resw
+++ b/AutoDarkModeApp/Strings/fr/Resources.resw
@@ -982,10 +982,13 @@ Version installée : {0}, nouvelle version : {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/he/Resources.resw
+++ b/AutoDarkModeApp/Strings/he/Resources.resw
@@ -982,10 +982,13 @@ Click "Yes" to open a new browser window.
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -982,10 +982,13 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/id/Resources.resw
+++ b/AutoDarkModeApp/Strings/id/Resources.resw
@@ -982,10 +982,13 @@ Versi saat ini: {0}, Versi terbaru: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/it/Resources.resw
+++ b/AutoDarkModeApp/Strings/it/Resources.resw
@@ -982,10 +982,13 @@ Versione attualmente installata: {0}, nuova versione: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ja/Resources.resw
+++ b/AutoDarkModeApp/Strings/ja/Resources.resw
@@ -972,10 +972,13 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ko/Resources.resw
+++ b/AutoDarkModeApp/Strings/ko/Resources.resw
@@ -982,10 +982,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nb-no/Resources.resw
+++ b/AutoDarkModeApp/Strings/nb-no/Resources.resw
@@ -982,10 +982,13 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/nl/Resources.resw
+++ b/AutoDarkModeApp/Strings/nl/Resources.resw
@@ -982,10 +982,13 @@ Momenteel geïnstalleerde versie: {0}, nieuwe versie: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pl/Resources.resw
+++ b/AutoDarkModeApp/Strings/pl/Resources.resw
@@ -982,10 +982,13 @@ Obecnie zainstalowana wersja: {0}, nowa wersja: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-br/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-br/Resources.resw
@@ -982,10 +982,13 @@ Versão instalada atualmente: {0}, nova versão: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/pt-pt/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-pt/Resources.resw
@@ -982,10 +982,13 @@ Versão instalada: {0}, Versão nova: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ro/Resources.resw
+++ b/AutoDarkModeApp/Strings/ro/Resources.resw
@@ -982,10 +982,13 @@ Versiunea instalată în prezent: {0}, versiune nouă: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/ru/Resources.resw
+++ b/AutoDarkModeApp/Strings/ru/Resources.resw
@@ -982,10 +982,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sr/Resources.resw
+++ b/AutoDarkModeApp/Strings/sr/Resources.resw
@@ -982,10 +982,13 @@ Trenutno instalirana verzija: {0}, nova verzija: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/sv/Resources.resw
+++ b/AutoDarkModeApp/Strings/sv/Resources.resw
@@ -982,10 +982,13 @@ Installerad version: {0}, ny version: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/tr/Resources.resw
+++ b/AutoDarkModeApp/Strings/tr/Resources.resw
@@ -982,10 +982,13 @@ Bunu indirmek istiyor musunuz?
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/uk/Resources.resw
+++ b/AutoDarkModeApp/Strings/uk/Resources.resw
@@ -976,10 +976,13 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/vi/Resources.resw
+++ b/AutoDarkModeApp/Strings/vi/Resources.resw
@@ -982,10 +982,13 @@ Phiên bản hiện tại của bạn: {0}, phiên bản mới: {1}</value>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hans/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hans/Resources.resw
@@ -966,10 +966,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -982,10 +982,13 @@
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Choose when the accent color should be applied</value>
   </data>
-  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Apply accent color to title bars and window borders</value>
+  <data name="ApplyDuring" xml:space="preserve">
+    <value>Apply during</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Apply accent color to the taskbar during dark mode</value>
+    <value>Accent color for the taskbar during dark mode</value>
+  </data>
+  <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
+    <value>Accent color for title bars and window borders</value>
   </data>
 </root>

--- a/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/SystemAreasViewModel.cs
@@ -32,7 +32,6 @@ public partial class SystemAreasViewModel : ObservableRecipient
 
     public bool LightTaskbarAccentPermitted => (Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_24H2);
 
-
     [ObservableProperty]
     public partial AppSwitchMode AppsSwitchComponentMode { get; set; }
 
@@ -46,10 +45,7 @@ public partial class SystemAreasViewModel : ObservableRecipient
     public partial bool IsDWMPrevalenceSwitch { get; set; }
 
     [ObservableProperty]
-    public partial bool IsDWMPrevalenceEnableThemeLight { get; set; }
-
-    [ObservableProperty]
-    public partial bool IsDWMPrevalenceEnableThemeDark { get; set; }
+    public partial int DWMPrevalenceMode { get; set; }
 
     [ObservableProperty]
     public partial bool IsTouchKeyboardSwitch { get; set; }
@@ -112,17 +108,17 @@ public partial class SystemAreasViewModel : ObservableRecipient
             SystemSwitchComponentMode = SystemSwitchMode.Disabled;
         }
 
-        IsTaskbarColorSwitch = (_builder.Config.SystemSwitch.Component.TaskbarColorSwitch && !(_builder.Config.SystemSwitch.Component.TaskbarColorDuring == Theme.Light));
+        IsTaskbarColorSwitch = (
+            _builder.Config.SystemSwitch.Component.TaskbarColorSwitch && !(_builder.Config.SystemSwitch.Component.TaskbarColorDuring == Theme.Light)
+        );
         IsDWMPrevalenceSwitch = _builder.Config.SystemSwitch.Component.DWMPrevalenceSwitch;
         if (_builder.Config.SystemSwitch.Component.DWMPrevalenceEnableTheme == Theme.Light)
         {
-            IsDWMPrevalenceEnableThemeLight = true;
-            IsDWMPrevalenceEnableThemeDark = false;
+            DWMPrevalenceMode = 0;
         }
         else
         {
-            IsDWMPrevalenceEnableThemeLight = false;
-            IsDWMPrevalenceEnableThemeDark = true;
+            DWMPrevalenceMode = 1;
         }
 
         IsTouchKeyboardSwitch = _builder.Config.TouchKeyboardSwitch.Enabled;
@@ -264,15 +260,14 @@ public partial class SystemAreasViewModel : ObservableRecipient
         RequestThemeSwitch();
     }
 
-    partial void OnIsDWMPrevalenceEnableThemeLightChanged(bool value)
+    partial void OnDWMPrevalenceModeChanged(int value)
     {
         if (_isInitializing)
-            return;
-
-        if (value)
         {
-            _builder.Config.SystemSwitch.Component.DWMPrevalenceEnableTheme = Theme.Light;
+            return;
         }
+
+        _builder.Config.SystemSwitch.Component.DWMPrevalenceEnableTheme = (value == 0) ? Theme.Light : Theme.Dark;
         try
         {
             _builder.Save();
@@ -281,29 +276,7 @@ public partial class SystemAreasViewModel : ObservableRecipient
         {
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
         }
-
-        if (value) RequestThemeSwitch();
-    }
-
-    partial void OnIsDWMPrevalenceEnableThemeDarkChanged(bool value)
-    {
-        if (_isInitializing)
-            return;
-
-        if (value)
-        {
-            _builder.Config.SystemSwitch.Component.DWMPrevalenceEnableTheme = Theme.Dark;
-        }
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SystemAreasViewModel");
-        }
-
-        if (value) RequestThemeSwitch();
+        RequestThemeSwitch();
     }
 
     partial void OnIsTouchKeyboardSwitchChanged(bool value)

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -46,8 +46,7 @@
                                            Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
                                            HeaderIcon="{ui:FontIcon Glyph=&#xEB41;}">
 
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
-
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
 
                     <controls:SettingsExpander.Items>
                         <controls:SettingsCard>

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -45,7 +45,7 @@
                 <controls:SettingsExpander
                     Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
                     Header="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
-                    HeaderIcon="{ui:FontIcon Glyph=&#xEB41;}">
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE737;}">
 
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
 

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -50,15 +50,11 @@
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
 
                     <controls:SettingsExpander.Items>
-                        <controls:SettingsCard>
-                            <controls:SettingsCard.Header>
-                                <StackPanel Orientation="Vertical">
-                                    <RadioButtons Header="{helpers:ResourceString Name=ApplyDuring}" IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
-                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
-                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeDark, Mode=TwoWay}" />
-                                    </RadioButtons>
-                                </StackPanel>
-                            </controls:SettingsCard.Header>
+                        <controls:SettingsCard Header="{helpers:ResourceString Name=ApplyDuring}" IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
+                            <ComboBox SelectedIndex="{x:Bind ViewModel.DWMPrevalenceMode, Mode=TwoWay}">
+                                <ComboBoxItem Content="{helpers:ResourceString Name=LightTheme}" />
+                                <ComboBoxItem Content="{helpers:ResourceString Name=DarkTheme}" />
+                            </ComboBox>
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -40,24 +40,20 @@
                     </ComboBox>
                 </controls:SettingsCard>
 
-                <!--  Accent Mode  -->
-                <controls:SettingsExpander Header="{helpers:ResourceString Name=AccentSurfaces}"
+
+                <!--  Accent Mode for title bars and window borders  -->
+                <controls:SettingsExpander Header="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
                                            Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
-                                       HeaderIcon="{ui:FontIcon Glyph=&#xE790;}">
+                                           HeaderIcon="{ui:FontIcon Glyph=&#xEB41;}">
+
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
+
+
                     <controls:SettingsExpander.Items>
-
-                        <controls:SettingsCard Header="{helpers:ResourceString Name=AccentApplyTaskbar}">
-                            <ToggleSwitch IsOn="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
-                        </controls:SettingsCard>
-
                         <controls:SettingsCard>
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
-                                    <CheckBox x:Name="DWMPrevalenceSwitcCheckBox"
-                                              Content="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
-                                              IsChecked="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
-
-                                    <RadioButtons IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
+                                    <RadioButtons Header="{helpers:ResourceString Name=ApplyDuring}"  IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
                                         <RadioButton Content="{helpers:ResourceString Name=LightTheme}"
                                                      IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
                                         <RadioButton Content="{helpers:ResourceString Name=DarkTheme}"
@@ -68,6 +64,15 @@
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
+
+                <!--  Accent mode for the taskbar -->
+                <controls:SettingsCard Header="{helpers:ResourceString Name=AccentApplyTaskbar}"
+                                       HeaderIcon="{ui:FontIcon Glyph=&#xE90E;}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
+
+               
 
                 <!--  Touch Keyboard  -->
                 <controls:SettingsCard Header="{helpers:ResourceString Name=SwitchTouchKeyboard}" HeaderIcon="{ui:FontIcon Glyph=&#xE92E;}">

--- a/AutoDarkModeApp/Views/SystemAreasPage.xaml
+++ b/AutoDarkModeApp/Views/SystemAreasPage.xaml
@@ -19,17 +19,6 @@
 
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=SystemAreas}" />
 
-                <!--  App Mode  -->
-                <controls:SettingsCard Header="{helpers:ResourceString Name=AppMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
-                    <ComboBox SelectedIndex="{x:Bind ViewModel.AppsSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
-                        <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
-                        <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
-                        <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysDark}" />
-                        <ComboBoxItem Content="{helpers:ResourceString Name=Disabled}" />
-                    </ComboBox>
-                </controls:SettingsCard>
-                
-
                 <!--  Windows mode  -->
                 <controls:SettingsCard Header="{helpers:ResourceString Name=WindowsMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE770;}">
                     <ComboBox SelectedIndex="{x:Bind ViewModel.SystemSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
@@ -40,11 +29,23 @@
                     </ComboBox>
                 </controls:SettingsCard>
 
+                <!--  App Mode  -->
+                <controls:SettingsCard Header="{helpers:ResourceString Name=AppMode}" HeaderIcon="{ui:FontIcon Glyph=&#xE71D;}">
+                    <ComboBox SelectedIndex="{x:Bind ViewModel.AppsSwitchComponentMode, Converter={StaticResource EnumToIndexConverter}, Mode=TwoWay}">
+                        <ComboBoxItem Content="{helpers:ResourceString Name=AdaptToSystem}" />
+                        <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysLight}" />
+                        <ComboBoxItem Content="{helpers:ResourceString Name=AlwaysDark}" />
+                        <ComboBoxItem Content="{helpers:ResourceString Name=Disabled}" />
+                    </ComboBox>
+                </controls:SettingsCard>
+
+
 
                 <!--  Accent Mode for title bars and window borders  -->
-                <controls:SettingsExpander Header="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
-                                           Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
-                                           HeaderIcon="{ui:FontIcon Glyph=&#xEB41;}">
+                <controls:SettingsExpander
+                    Description="{helpers:ResourceString Name=AccentSurfacesChoose}"
+                    Header="{helpers:ResourceString Name=AccentApplyTitlebarAndBorders}"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xEB41;}">
 
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=TwoWay}" />
 
@@ -52,11 +53,9 @@
                         <controls:SettingsCard>
                             <controls:SettingsCard.Header>
                                 <StackPanel Orientation="Vertical">
-                                    <RadioButtons Header="{helpers:ResourceString Name=ApplyDuring}"  IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
-                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}"
-                                                     IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
-                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}"
-                                                     IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeDark, Mode=TwoWay}" />
+                                    <RadioButtons Header="{helpers:ResourceString Name=ApplyDuring}" IsEnabled="{x:Bind ViewModel.IsDWMPrevalenceSwitch, Mode=OneWay}">
+                                        <RadioButton Content="{helpers:ResourceString Name=LightTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeLight, Mode=TwoWay}" />
+                                        <RadioButton Content="{helpers:ResourceString Name=DarkTheme}" IsChecked="{x:Bind ViewModel.IsDWMPrevalenceEnableThemeDark, Mode=TwoWay}" />
                                     </RadioButtons>
                                 </StackPanel>
                             </controls:SettingsCard.Header>
@@ -64,14 +63,12 @@
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
 
-                <!--  Accent mode for the taskbar -->
-                <controls:SettingsCard Header="{helpers:ResourceString Name=AccentApplyTaskbar}"
-                                       HeaderIcon="{ui:FontIcon Glyph=&#xE90E;}">
+                <!--  Accent mode for the taskbar  -->
+                <controls:SettingsCard Header="{helpers:ResourceString Name=AccentApplyTaskbar}" HeaderIcon="{ui:FontIcon Glyph=&#xE90E;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.IsTaskbarColorSwitch, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
 
-               
 
                 <!--  Touch Keyboard  -->
                 <controls:SettingsCard Header="{helpers:ResourceString Name=SwitchTouchKeyboard}" HeaderIcon="{ui:FontIcon Glyph=&#xE92E;}">

--- a/AutoDarkModeSvc/AutoDarkModeSvc.csproj
+++ b/AutoDarkModeSvc/AutoDarkModeSvc.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>11.0.0.42</Version>
+    <Version>11.0.0.43</Version>
     <AssemblyName>AutoDarkModeSvc</AssemblyName>
     <ApplicationIcon>..\adm_tray_new.ico</ApplicationIcon>
     <StartupObject>AutoDarkModeSvc.Program</StartupObject>

--- a/AutoDarkModeSvc/AutoDarkModeSvc.csproj
+++ b/AutoDarkModeSvc/AutoDarkModeSvc.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>11.0.0.43</Version>
+    <Version>11.0.0.44</Version>
     <AssemblyName>AutoDarkModeSvc</AssemblyName>
     <ApplicationIcon>..\adm_tray_new.ico</ApplicationIcon>
     <StartupObject>AutoDarkModeSvc.Program</StartupObject>


### PR DESCRIPTION
Regroups the accent color settings into their own settings panels, and uses toggles wherever possible.

<img width="1349" height="1055" alt="image" src="https://github.com/user-attachments/assets/3e730a10-2409-4972-8795-5a67cf5ec218" />

closes #999
