### PR TITLE
Feat: Permit Spotlight in Backend for 22H2 ubr 4239

### DIFF
--- a/AutoDarkModeLib/Enums.cs
+++ b/AutoDarkModeLib/Enums.cs
@@ -120,6 +120,7 @@ public enum BridgeResponseCode
 
 public enum WindowsBuilds : int
 {
+    Win10_22H2 = 19045,
     Win11_RC = 22000,
     Win11_22H2 = 22621,
     Win11_23H2 = 22631,
@@ -128,5 +129,6 @@ public enum WindowsBuilds : int
 
 public enum WindowsBuildsUbr : int
 {
+    Win10_22H2_Spotlight = 4239,
     Win11_22H2_Spotlight = 1105
 }

--- a/AutoDarkModeSvc/SwitchComponents/Base/WallpaperSwitch.cs
+++ b/AutoDarkModeSvc/SwitchComponents/Base/WallpaperSwitch.cs
@@ -58,7 +58,20 @@ internal class WallpaperSwitch : BaseComponent<WallpaperSwitchSettings>
         }
         else if (Environment.OSVersion.Version.Build < (int)WindowsBuilds.Win11_22H2)
         {
-            Logger.Warn($"spotlight not supported on build {WindowsBuilds.Win11_22H2}");
+            if (Environment.OSVersion.Version.Build == (int)WindowsBuilds.Win10_22H2)
+            {
+                bool hasUbr = int.TryParse(RegistryHandler.GetUbr(), out int ubr);
+                if (hasUbr)
+                {
+                    if (ubr >= (int)WindowsBuildsUbr.Win10_22H2_Spotlight)
+                    {
+                        return true;
+                    }
+                    Logger.Warn($"spotlight not supported on build {Environment.OSVersion.Version.Build}.{ubr}");
+                    return false;
+                }
+            }
+            Logger.Warn($"spotlight not supported on build {Environment.OSVersion.Version.Build}");
             return false;
         }
 


### PR DESCRIPTION
Enables spotlight in the wallpaper switcher component for win10 builds that have the option available.