### PR TITLE
Feature: Permit Spotlight in Frontend for 22H2

### DIFF
--- a/AutoDarkModeApp/ViewModels/WallpaperPickerViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/WallpaperPickerViewModel.cs
@@ -162,11 +162,13 @@ public partial class WallpaperPickerViewModel : ObservableRecipient
         if (
             hasUbr
             && (
-                (Environment.OSVersion.Version.Build == (int)WindowsBuilds.Win11_22H2 && ubr >= (int)WindowsBuildsUbr.Win11_22H2_Spotlight)
-                || Environment.OSVersion.Version.Build > (int)WindowsBuilds.Win11_22H2
+                (Environment.OSVersion.Version.Build == (int)WindowsBuilds.Win10_22H2 && ubr >= (int)WindowsBuildsUbr.Win10_22H2_Spotlight)
+                || Environment.OSVersion.Version.Build > (int)WindowsBuilds.Win10_22H2
             )
         )
+        {
             SpotlightEnabled = true;
+        }
 
         IsWallpaperSwitchEnabled = _builder.Config.WallpaperSwitch.Enabled;
 


### PR DESCRIPTION
### Description

Enables spotlight in the wallpaper pick page for win10 builds that have the option available.