### PR TITLE
Fix: The Crash of ColorizationPage in Non-debugging Mode

### DIFF
--- a/AutoDarkModeApp/Views/ColorizationPage.xaml
+++ b/AutoDarkModeApp/Views/ColorizationPage.xaml
@@ -40,11 +40,33 @@
 
                 <!--  Accent Color  -->
                 <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+
+                    <!--  Automatic color mode info  -->
+                    <InfoBar
+                        IsClosable="False"
+                        IsOpen="{x:Bind ViewModel.AutomaticColorPromptSettingsCardVisibility, Mode=OneWay}"
+                        Message="{helpers:ResourceString Name=Msg_AutomaticColorModeDescription}"
+                        Severity="Informational" />
+
+                    <!--  Automatic color mode settingscard  -->
+                    <controls:SettingsCard
+                        Header="{helpers:ResourceString Name=AccentColor}"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE790;}"
+                        IsEnabled="{x:Bind ViewModel.IsColorizationEnabled, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.AutomaticColorPromptSettingsCardVisibility, Mode=OneWay}">
+                        <ComboBox SelectedIndex="{x:Bind ViewModel.AccentColorMode, Mode=TwoWay, Converter={StaticResource EnumToIndexConverter}}" SelectionChanged="AccentColorModeComboBox_SelectionChanged">
+                            <ComboBoxItem Content="{helpers:ResourceString Name=Automatic}" />
+                            <ComboBoxItem Content="{helpers:ResourceString Name=Manual}" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+
+                    <!--  Manual color mode settingsexpander  -->
                     <controls:SettingsExpander
                         Header="{helpers:ResourceString Name=AccentColor}"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE790;}"
                         IsEnabled="{x:Bind ViewModel.IsColorizationEnabled, Mode=OneWay}"
-                        IsExpanded="{x:Bind ViewModel.ManualColorSelectionSettingsCardVisibility, Mode=OneWay}">
+                        IsExpanded="True"
+                        Visibility="{x:Bind ViewModel.ManualColorSelectionSettingsCardVisibility, Mode=OneWay}">
                         <ComboBox SelectedIndex="{x:Bind ViewModel.AccentColorMode, Mode=TwoWay, Converter={StaticResource EnumToIndexConverter}}" SelectionChanged="AccentColorModeComboBox_SelectionChanged">
                             <ComboBoxItem Content="{helpers:ResourceString Name=Automatic}" />
                             <ComboBoxItem Content="{helpers:ResourceString Name=Manual}" />
@@ -53,6 +75,7 @@
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard ContentAlignment="Left" Visibility="{x:Bind ViewModel.ManualColorSelectionSettingsCardVisibility, Mode=OneWay}">
                                 <StackPanel Orientation="Vertical" Spacing="8">
+
                                     <!--  Currently selected color  -->
                                     <TextBlock Text="{helpers:ResourceString Name=SelectedColor}" />
                                     <GridView SelectionMode="None">
@@ -106,10 +129,6 @@
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
 
-                    <InfoBar IsClosable="False"
-                             IsOpen="{x:Bind ViewModel.AutomaticColorPromptSettingsCardVisibility, Mode=OneWay}"
-                             Message="{helpers:ResourceString Name=Msg_AutomaticColorModeDescription}"
-                             Severity="Informational" />
                 </StackPanel>
 
                 <!--  TODO: Follow https://learn.microsoft.com/windows/apps/design/controls/dialogs-and-flyouts/dialogs  -->


### PR DESCRIPTION
### Description

Fix https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/issues/1106#issuecomment-3417514099.

### Screenshots

<img width="1121" height="710" alt="image" src="https://github.com/user-attachments/assets/57f53f4c-28d4-414f-acdf-cb2f33701ef2" />

<img width="1131" height="698" alt="image" src="https://github.com/user-attachments/assets/ccf27419-767a-4b2e-95ce-e3c685b8edaa" />
