### PR TITLE
Code quality and Fix: Front end and back end about hotkey function

### DIFF
--- a/AutoDarkModeApp/Models/HotkeysDataObject.cs
+++ b/AutoDarkModeApp/Models/HotkeysDataObject.cs
@@ -1,0 +1,15 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AutoDarkModeApp.Models;
+
+public partial class HotkeysDataObject : ObservableObject
+{
+    [ObservableProperty]
+    public partial string? DisplayName { get; set; }
+
+    [ObservableProperty]
+    public partial string? Keys { get; set; }
+
+    [ObservableProperty]
+    public partial string? Tag { get; set; }
+}

--- a/AutoDarkModeApp/Models/HotkeysDataObject.cs
+++ b/AutoDarkModeApp/Models/HotkeysDataObject.cs
@@ -1,5 +1,5 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using Windows.System;
+﻿using AutoDarkModeLib;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AutoDarkModeApp.Models;
 
@@ -14,71 +14,7 @@ public partial class HotkeysDataObject : ObservableObject
     [ObservableProperty]
     public partial string? Tag { get; set; }
 
-    public string? DisplayKeys => ConvertToDisplayFormat(Keys);
-
-    private static string? ConvertToDisplayFormat(string? hotkeyConfig)
-    {
-        if (string.IsNullOrEmpty(hotkeyConfig))
-        {
-            return null;
-        }
-
-        var parts = hotkeyConfig.Split(',');
-        if (parts.Length != 2 || !uint.TryParse(parts[0], out uint modifiers) || !uint.TryParse(parts[1], out uint keyCode))
-        {
-            return hotkeyConfig;
-        }
-
-        List<string> displayParts = [];
-
-        if ((modifiers & 2) != 0)
-        {
-            displayParts.Add("Ctrl");
-        }
-        if ((modifiers & 4) != 0)
-        {
-            displayParts.Add("Shift");
-        }
-        if ((modifiers & 1) != 0)
-        {
-            displayParts.Add("Alt");
-        }
-        if ((modifiers & 8) != 0)
-        {
-            displayParts.Add("Win");
-        }
-
-        displayParts.Add(GetKeyDisplayName((VirtualKey)keyCode));
-
-        return string.Join(" + ", displayParts);
-    }
-
-    private static string GetKeyDisplayName(VirtualKey key)
-    {
-        return key switch
-        {
-            VirtualKey.Enter => "Enter",
-            VirtualKey.Escape => "Esc",
-            VirtualKey.Space => "Space",
-            VirtualKey.Back => "Backspace",
-            VirtualKey.Delete => "Del",
-            VirtualKey.PageUp => "PgUp",
-            VirtualKey.PageDown => "PgDn",
-            VirtualKey.CapitalLock => "CapsLock",
-            (VirtualKey)188 => ",",
-            (VirtualKey)190 => ".",
-            (VirtualKey)191 => "/",
-            (VirtualKey)187 => "=",
-            (VirtualKey)189 => "-",
-            (VirtualKey)219 => "[",
-            (VirtualKey)221 => "]",
-            (VirtualKey)220 => "\\",
-            (VirtualKey)186 => ";",
-            (VirtualKey)222 => "'",
-            (VirtualKey)192 => "`",
-            _ => key.ToString(),
-        };
-    }
+    public string? DisplayKeys => HotkeyStringConverter.ToDisplayFormat(Keys);
 
     partial void OnKeysChanged(string? value)
     {

--- a/AutoDarkModeApp/Models/HotkeysDataObject.cs
+++ b/AutoDarkModeApp/Models/HotkeysDataObject.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Windows.System;
 
 namespace AutoDarkModeApp.Models;
 
@@ -12,4 +13,75 @@ public partial class HotkeysDataObject : ObservableObject
 
     [ObservableProperty]
     public partial string? Tag { get; set; }
+
+    public string? DisplayKeys => ConvertToDisplayFormat(Keys);
+
+    private static string? ConvertToDisplayFormat(string? hotkeyConfig)
+    {
+        if (string.IsNullOrEmpty(hotkeyConfig))
+        {
+            return null;
+        }
+
+        var parts = hotkeyConfig.Split(',');
+        if (parts.Length != 2 || !uint.TryParse(parts[0], out uint modifiers) || !uint.TryParse(parts[1], out uint keyCode))
+        {
+            return hotkeyConfig;
+        }
+
+        List<string> displayParts = [];
+
+        if ((modifiers & 2) != 0)
+        {
+            displayParts.Add("Ctrl");
+        }
+        if ((modifiers & 4) != 0)
+        {
+            displayParts.Add("Shift");
+        }
+        if ((modifiers & 1) != 0)
+        {
+            displayParts.Add("Alt");
+        }
+        if ((modifiers & 8) != 0)
+        {
+            displayParts.Add("Win");
+        }
+
+        displayParts.Add(GetKeyDisplayName((VirtualKey)keyCode));
+
+        return string.Join(" + ", displayParts);
+    }
+
+    private static string GetKeyDisplayName(VirtualKey key)
+    {
+        return key switch
+        {
+            VirtualKey.Enter => "Enter",
+            VirtualKey.Escape => "Esc",
+            VirtualKey.Space => "Space",
+            VirtualKey.Back => "Backspace",
+            VirtualKey.Delete => "Del",
+            VirtualKey.PageUp => "PgUp",
+            VirtualKey.PageDown => "PgDn",
+            VirtualKey.CapitalLock => "CapsLock",
+            (VirtualKey)188 => ",",
+            (VirtualKey)190 => ".",
+            (VirtualKey)191 => "/",
+            (VirtualKey)187 => "=",
+            (VirtualKey)189 => "-",
+            (VirtualKey)219 => "[",
+            (VirtualKey)221 => "]",
+            (VirtualKey)220 => "\\",
+            (VirtualKey)186 => ";",
+            (VirtualKey)222 => "'",
+            (VirtualKey)192 => "`",
+            _ => key.ToString(),
+        };
+    }
+
+    partial void OnKeysChanged(string? value)
+    {
+        OnPropertyChanged(nameof(DisplayKeys));
+    }
 }

--- a/AutoDarkModeApp/Strings/ar/Resources.resw
+++ b/AutoDarkModeApp/Strings/ar/Resources.resw
@@ -1015,9 +1015,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/cs/Resources.resw
+++ b/AutoDarkModeApp/Strings/cs/Resources.resw
@@ -1018,9 +1018,6 @@ Ve vzácných případech může systém Windows při pohybu myší během obnov
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/de/Resources.resw
+++ b/AutoDarkModeApp/Strings/de/Resources.resw
@@ -164,7 +164,7 @@ In seltenen Fällen kann sogar ein Piepston auftauchen, wenn die Maus während d
     <value>Automatisch</value>
   </data>
   <data name="AutomaticThemeSwitch" xml:space="preserve">
-    <value>Auto-Wechsel an/ausschalten</value>
+    <value>Auto-Wechsel an-/ausschalten</value>
   </data>
   <data name="AutoStart" xml:space="preserve">
     <value>Autostart</value>
@@ -319,9 +319,8 @@ Bitte stelle sicher, dass:
 - der Service läuft
 - die config.yaml Datei korrekt ist
 
-Möchtest du eine Fehlermeldung in unserem GitHub Repo erstellen?
-Drücke "ja", um ein neues Browserfenster zu öffnen.
-</value>
+Möchtest du eine Fehlermeldung in unserem GitHub-Repository erstellen?
+Drücke "ja", um ein neues Browserfenster zu öffnen.</value>
   </data>
   <data name="ErrorOccurred_Title" xml:space="preserve">
     <value>Ein Fehler ist aufgetreten</value>
@@ -677,7 +676,7 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Designwechsel unterbinden, während bestimmte Apps ausgeführt werden</value>
   </data>
   <data name="RefreshAutostart" xml:space="preserve">
-    <value>Autostart aktualisieren</value>
+    <value>Aktualisieren</value>
   </data>
   <data name="RegistryKey" xml:space="preserve">
     <value>Registrierungsschlüssel</value>
@@ -867,15 +866,15 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Autostart ist via Windows deaktiviert.</value>
   </data>
   <data name="ThemeTutorialDescription" xml:space="preserve">
-    <value>1. Go to Windows Settings &gt; Personalization &gt; Colors.
-2. Change the system color to 'Light' for the light theme.
-3. Go to Windows Settings &gt; Personalization &gt; Themes.
-4. Select your favorite wallpaper, mouse pointers and accent color.
-5. Save your theme.
-6. Repeat this process for the dark theme.</value>
+    <value>1. Gehe zu den Windows-Einstellungen &gt; Personalisierung &gt; Farben.
+2. Ändere den Modus für das helle Design auf „Hell”.
+3. Gehe zu den Windows-Einstellungen &gt; Personalisierung &gt; Designs.
+4. Wähle dein bevorzugtes Hintergrundbild, den Mauszeiger und die Akzentfarbe aus.
+5. Speichere dein Design.
+6. Wiederhole diesen Vorgang für das dunkle Design.</value>
   </data>
   <data name="EditHotkey" xml:space="preserve">
-    <value>Edit hotkey</value>
+    <value>Tastenkürzel bearbeiten</value>
   </data>
   <data name="DisplayMonitorDisconnected" xml:space="preserve">
     <value>Nicht verbunden</value>
@@ -900,16 +899,16 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Beta</value>
   </data>
   <data name="DebugMode" xml:space="preserve">
-    <value>Debug Modus</value>
+    <value>Debug-Modus</value>
   </data>
   <data name="EnterToApply" xml:space="preserve">
     <value>Drücke Enter zum Anwenden</value>
   </data>
   <data name="Language" xml:space="preserve">
-    <value>Language</value>
+    <value>Sprache</value>
   </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
-    <value>Go to Windows Spotlight settings</value>
+    <value>Gehe zu den Windows Spotlight-Einstellungen</value>
   </data>
   <data name="Stable" xml:space="preserve">
     <value>Stable</value>
@@ -918,10 +917,10 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Wechseln</value>
   </data>
   <data name="ShowNotificationPostponeToggled" xml:space="preserve">
-    <value>Zeige Benachrichtigung bei Pausierung des automatischen Designwechsels</value>
+    <value>Zeige eine Benachrichtigung bei Pausierung des automatischen Designwechsels</value>
   </data>
   <data name="ShowNotificationAutomaticThemeToggled" xml:space="preserve">
-    <value>Zeige Benachrichtigung bei Auslöse des automatischen Designwechsels</value>
+    <value>Zeige Benachrichtigung bei Auslösung des automatischen Designwechsels</value>
   </data>
   <data name="SelectTheKeyCombination" xml:space="preserve">
     <value>Drücke eine Kombination an Tasten. Es sind nur Tastenkürzel erlaubt, die mit der Windows-Taste, Strg, Alt oder Shift beginnen.</value>
@@ -936,7 +935,7 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Speichern</value>
   </data>
   <data name="Msg_HotkeyProblem" xml:space="preserve">
-    <value>Die Tastenkürzel funktionieren nicht? Keine Sorge, hier kannst du sie nochmal speichern</value>
+    <value>Die Tastenkürzel funktionieren nicht? Keine Sorge, hier kannst du sie nochmal speichern.</value>
   </data>
   <data name="SaveSuccessfully" xml:space="preserve">
     <value>Speicherung erfolgreich</value>
@@ -966,7 +965,7 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Akzentfarbe ignorieren</value>
   </data>
   <data name="AccentSurfaces" xml:space="preserve">
-    <value>Accent Surfaces</value>
+    <value>Akzentfarbenflächen</value>
   </data>
   <data name="AccentSurfacesChoose" xml:space="preserve">
     <value>Wähle aus, wann die Akzentfarbe angewendet werden soll</value>
@@ -996,13 +995,13 @@ Aktuell installierte Version: {0}, neue Version: {1}</value>
     <value>Dark Mode für deinen Internetbrowser</value>
   </data>
   <data name="DarkModeForWebbrowserDescription" xml:space="preserve">
-    <value>Dark Reader ist eine Browsererweiterung für Chrome, Edge und Firefox, die Webseiten in den Dark Mode einfärbt. Klick hier, um mehr zu erfahren</value>
+    <value>Dark Reader ist eine Browsererweiterung für Chrome, Edge und Firefox, die Webseiten in den Dark Mode einfärbt. Klicke hier, um mehr zu erfahren.</value>
   </data>
   <data name="WindowsMousePointerSetting" xml:space="preserve">
     <value>Öffne die Windows Mauszeigereinstellungen</value>
   </data>
   <data name="WindowsMousePointerSettingDescription" xml:space="preserve">
-    <value>Definiere neue Mauszeigervorlagen in den Windows-Einstellungen, die anschließend hier zur Wahl stehen</value>
+    <value>Definiere neue Mauszeigervorlagen in den Windows-Einstellungen, die anschließend hier zur Wahl stehen.</value>
   </data>
   <data name="FitMode_Center" xml:space="preserve">
     <value>Zentriert</value>

--- a/AutoDarkModeApp/Strings/de/Resources.resw
+++ b/AutoDarkModeApp/Strings/de/Resources.resw
@@ -1019,9 +1019,6 @@ In seltenen Fällen kann sogar ein Piepston auftauchen, wenn die Maus während d
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Windows-Einstellungen öffnen</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/el-gr/Resources.resw
+++ b/AutoDarkModeApp/Strings/el-gr/Resources.resw
@@ -1012,9 +1012,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -1012,9 +1012,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/es/Resources.resw
+++ b/AutoDarkModeApp/Strings/es/Resources.resw
@@ -214,7 +214,7 @@ En casos excepcionales, Windows puede emitir un pitido cuando se mueve el mouse 
     <value>Color</value>
   </data>
   <data name="ColorFilter" xml:space="preserve">
-    <value>Filtro de color (usa Win + Ctrl + C)</value>
+    <value>Activar filtro de color en el modo oscuro</value>
   </data>
   <data name="ColorizationPick_Description" xml:space="preserve">
     <value>Personaliza el esquema de colores del sistema de Windows a tu gusto.</value>

--- a/AutoDarkModeApp/Strings/es/Resources.resw
+++ b/AutoDarkModeApp/Strings/es/Resources.resw
@@ -1018,9 +1018,6 @@ En casos excepcionales, Windows puede emitir un pitido cuando se mueve el mouse 
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -1018,9 +1018,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -121,16 +121,16 @@
     <value>حالت تاریک خوکار</value>
   </data>
   <data name="About" xml:space="preserve">
-    <value>درباره</value>
+    <value>Settings</value>
   </data>
   <data name="AccentColor" xml:space="preserve">
-    <value>Accent color</value>
+    <value>رنگ تأکیدی</value>
   </data>
   <data name="AccentOnly" xml:space="preserve">
-    <value>Accent only</value>
+    <value>فقط تأکیدی</value>
   </data>
   <data name="ActiveDelays" xml:space="preserve">
-    <value>Active delays</value>
+    <value>فعالسازی تأخیرها</value>
   </data>
   <data name="AdaptiveTaskbarAccent" xml:space="preserve">
     <value>Use Taskbar Accent Color during</value>
@@ -147,7 +147,8 @@
   <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
     <value>Attempts to reduce the occurrence of wrong UI colors in the explorer, taskbar and start menu. If you experience this often or are bothered by it, try enabling this setting.
 
-This may introduce slight to moderate lag on some systems during theme switch similar to how it happened in Windows 10. 
+This may introduce slight to moderate lag on some systems during theme switch similar to how it happened in Windows 10.
+
 On rare occasions, Windows may emit a beeping sound when the mouse is moved during DWM refreshes.</value>
   </data>
   <data name="Apply" xml:space="preserve">
@@ -160,7 +161,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>بار گیری و نصب خودکار ویرایش‌های جدید</value>
   </data>
   <data name="Automatic" xml:space="preserve">
-    <value>Automatic</value>
+    <value>خودکار</value>
   </data>
   <data name="AutomaticThemeSwitch" xml:space="preserve">
     <value>Toggle automatic theme switch</value>
@@ -214,7 +215,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>رنگ</value>
   </data>
   <data name="ColorFilter" xml:space="preserve">
-    <value>فیلتر رنگی (ارسال با Win + Ctrl + C)</value>
+    <value>فعالسازی فیلتر رنگی هنگام فعال بودن حالت تاریک</value>
   </data>
   <data name="ColorizationPick_Description" xml:space="preserve">
     <value>Customize the Windows system color scheme to your liking.</value>
@@ -226,13 +227,13 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>پیکربندی</value>
   </data>
   <data name="Confirm" xml:space="preserve">
-    <value>Confirm</value>
+    <value>تأیید</value>
   </data>
   <data name="Copy" xml:space="preserve">
     <value>رونوشت</value>
   </data>
   <data name="CreateTheme" xml:space="preserve">
-    <value>نمایه‌ی خود را بسازید.</value>
+    <value>نمایه‌های خود را بسازید</value>
   </data>
   <data name="Cursors" xml:space="preserve">
     <value>Cursors</value>
@@ -253,7 +254,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>نمایه تاریک</value>
   </data>
   <data name="Delay" xml:space="preserve">
-    <value>Delay</value>
+    <value>تأخیر</value>
   </data>
   <data name="Disabled" xml:space="preserve">
     <value>غیرفعال شده</value>
@@ -270,8 +271,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="Donation_Description" xml:space="preserve">
     <value>سلام، سپاس برای استفاده شما از Auto Dark Mode! آیا تا کنون آن‌را دوست داشته اید؟ 
 
-این برنامه با کمک به مراقبت از چشمانتان روز لذت بخش‌تری را برایتان به ارمغان می‌آورد .
-من با این پروژه هیچ سودی بدست نمی آورم.
+این برنامه با کمک به مراقبت از چشمانتان روز لذت بخش‌تری را برایتان به ارمغان می‌آورد. من با این پروژه هیچ سودی بدست نمی آورم.
 
 به همین دلیل می‌توانید با یک کمک مالی داوطلبانه از من حمایت کنید. حتی مقدار کمی می‌تواند باعث خوشحالی من بشود. فقط به‌ اندازه‌ای که برای کار من ارزش قائلید کمک کنید.</value>
   </data>
@@ -318,12 +318,10 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
 - سرویس برنامه در حال اجرا است
 - فایل config.yaml شما سالم است
 
-آیا می‌خواهید یک تیکت در ریپوزیتوری Auto Dark Mode ایجاد کنید؟
-برای باز کردن یک پنجره جدید در مرورگر روی «آری» کلید کنید.
-</value>
+آیا می‌خواهید یک تیکت در ریپوزیتوری Auto Dark Mode ایجاد کنید؟</value>
   </data>
   <data name="ErrorOccurred_Title" xml:space="preserve">
-    <value>یک خطا رخ داده است.</value>
+    <value>یک خطا رخ داده است</value>
   </data>
   <data name="FeatureDisabled_WhileManagedMode" xml:space="preserve">
     <value>هنگامی که Auto Dark Mode نمایه‌ی شما را مدیریت می‌کند، این ویژگی غیرفعال است.</value>
@@ -455,7 +453,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>طول جغرافیایی</value>
   </data>
   <data name="ManagedMode" xml:space="preserve">
-    <value>Let Auto Dark Mode manage my theme</value>
+    <value>بگذارید Auto Dark Mode، پوسته من را مدیریت کند (توصیه می‌شود)</value>
   </data>
   <data name="Manual" xml:space="preserve">
     <value>Manual</value>
@@ -503,7 +501,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>سرویس برنامه هنوز اجرا نشده است، لطفا صبر کنید…</value>
   </data>
   <data name="Msg_NoUpdate" xml:space="preserve">
-    <value>هیچ بروزرسانی جدیدی در دسترس نیست.</value>
+    <value>هیچ بروزرسانی جدیدی در دسترس نیست</value>
   </data>
   <data name="Msg_PauseOnce" xml:space="preserve">
     <value>Theme switching is paused once!</value>
@@ -530,10 +528,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>یک بروزرسانی جدید در دسترس است!</value>
   </data>
   <data name="Msg_UpdaterText" xml:space="preserve">
-    <value>از اینکه از نمایه تاریک خودکار استفاده میکنید متشکریم!
-
-نسخه جدیدی در گیت هاب با حل مشکلات و برخی بهبودها موجود است.
-آیا می خواهید دانلودش کنید؟
+    <value>نسخه جدیدی در گیت هاب با حل مشکلات و برخی بهبودها موجود است.
 
 در حال نصب نسخه:{0}، نسخه جدید:{1}</value>
   </data>
@@ -676,7 +671,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>Don't switch while certain processes are running</value>
   </data>
   <data name="RefreshAutostart" xml:space="preserve">
-    <value>تازه‌سازی جرای خودکار</value>
+    <value>تازه‌سازی</value>
   </data>
   <data name="RegistryKey" xml:space="preserve">
     <value>Registry Key</value>
@@ -694,7 +689,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>اجرای دوباره</value>
   </data>
   <data name="RestartNeeded" xml:space="preserve">
-    <value>برای مشاهده تغییرات، نیاز به اجرای دوباره برنامه است.</value>
+    <value>برای مشاهده تغییرات، نیاز به اجرای دوباره برنامه است</value>
   </data>
   <data name="RestoreThemeChanged" xml:space="preserve">
     <value>بازگردانی نمایه‌ها هنگامی که به صورت خارجی تغییر کرده‌اند</value>
@@ -824,7 +819,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>Let Windows manage my theme</value>
   </data>
   <data name="UpdateAtStart" xml:space="preserve">
-    <value>بررسی بروزرسانی همزمان با اجرای Auto Dark Mode</value>
+    <value>بررسی همزمان با اجرای Auto Dark Mode</value>
   </data>
   <data name="UpdateChannel" xml:space="preserve">
     <value>انتخاب کانال بروزرسانی</value>
@@ -860,7 +855,7 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>Windows spotlight</value>
   </data>
   <data name="Warning1903" xml:space="preserve">
-    <value>این گزینه غیر فعال است؛ زیرا شما بروزرسانی  Windows 10 April 2019 را نصب نکرده اید.</value>
+    <value>این گزینه غیر فعال است؛ زیرا شما بروزرسانی Windows 10 April 2019 یا بالاتر را نصب نکرده اید.</value>
   </data>
   <data name="WindowsAutostartDisabled" xml:space="preserve">
     <value>شما اجرای خودکار با ویندوز را غیر فعال کرده اید.</value>
@@ -896,25 +891,25 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
     <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
   </data>
   <data name="Beta" xml:space="preserve">
-    <value>Beta</value>
+    <value>آزمایشی</value>
   </data>
   <data name="DebugMode" xml:space="preserve">
-    <value>Debug mode</value>
+    <value>حالت عیب یابی</value>
   </data>
   <data name="EnterToApply" xml:space="preserve">
     <value>Select Enter to apply</value>
   </data>
   <data name="Language" xml:space="preserve">
-    <value>Language</value>
+    <value>زبان</value>
   </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
     <value>Go to Windows Spotlight settings</value>
   </data>
   <data name="Stable" xml:space="preserve">
-    <value>Stable</value>
+    <value>پایدار</value>
   </data>
   <data name="Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>جابجایی</value>
   </data>
   <data name="ShowNotificationPostponeToggled" xml:space="preserve">
     <value>Show notification when the automatic theme switch is paused</value>

--- a/AutoDarkModeApp/Strings/fa/Resources.resw
+++ b/AutoDarkModeApp/Strings/fa/Resources.resw
@@ -983,12 +983,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OffsetTime_Description" xml:space="preserve">
     <value>Positive values are later, negative values are earlier</value>
   </data>
-  <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
-    <value>Attempts to reduce the occurrence of wrong UI colors in the explorer, taskbar and start menu. If you experience this often or are bothered by it, try enabling this setting.
-
-This may introduce slight to moderate lag on some systems during theme switch similar to how it happened in Windows 10.
-On rare occasions, Windows may emit a beeping sound when the mouse is moved during DWM refreshes.</value>
-  </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
     <value>Use aggressive DWM refresh?</value>
   </data>

--- a/AutoDarkModeApp/Strings/fr/Resources.resw
+++ b/AutoDarkModeApp/Strings/fr/Resources.resw
@@ -1018,9 +1018,6 @@ Dans de rares cas, Windows peut émettre un bip sonore lorsque la souris est dé
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/he/Resources.resw
+++ b/AutoDarkModeApp/Strings/he/Resources.resw
@@ -1018,9 +1018,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -986,12 +986,6 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
   <data name="OffsetTime_Description" xml:space="preserve">
     <value>Pozitív értékek később, negatív értékek korábban</value>
   </data>
-  <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
-    <value>Megpróbálja csökkenteni a helytelen felhasználói felületi színek előfordulását a fájlkezelőben, a tálcán és a Start menüben. Ha ezt gyakran tapasztalja, vagy zavarja, próbálja meg engedélyezni ezt a beállítást.
-
-Ez enyhe vagy közepes késést okozhat egyes rendszereken a témaváltás során, hasonlóan ahhoz, ahogy a Windows 10 rendszerben történt.
-Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissítése közben mozgatják.</value>
-  </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
     <value>Use aggressive DWM refresh?</value>
   </data>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -147,7 +147,8 @@
   <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
     <value>Megpróbálja csökkenteni a helytelen felhasználói felületi színek előfordulását a fájlkezelőben, a tálcán és a Start menüben. Ha ezt gyakran tapasztalja, vagy zavarja, próbálja meg engedélyezni ezt a beállítást.
 
-Ez enyhe vagy közepes késést okozhat egyes rendszereken a témaváltás során, hasonlóan ahhoz, ahogy a Windows 10 rendszerben történt. 
+Ez enyhe vagy közepes késést okozhat egyes rendszereken a témaváltás során, hasonlóan ahhoz, ahogy a Windows 10 rendszerben történt.
+
 Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissítése közben mozgatják.</value>
   </data>
   <data name="Apply" xml:space="preserve">
@@ -163,7 +164,7 @@ Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissít
     <value>Automatikus</value>
   </data>
   <data name="AutomaticThemeSwitch" xml:space="preserve">
-    <value>Az automatikus témaváltás kapcsolása</value>
+    <value>Automatikus témaváltás kapcsolása</value>
   </data>
   <data name="AutoStart" xml:space="preserve">
     <value>Autostart</value>
@@ -214,7 +215,7 @@ Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissít
     <value>Color</value>
   </data>
   <data name="ColorFilter" xml:space="preserve">
-    <value>Színszűrő (Win + Ctrl + C)</value>
+    <value>Színszűrő engedélyezése sötét mód alatt</value>
   </data>
   <data name="ColorizationPick_Description" xml:space="preserve">
     <value>Testreszabhatja a Windows rendszer színsémáját tetszés szerint.</value>
@@ -270,8 +271,7 @@ Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissít
   <data name="Donation_Description" xml:space="preserve">
     <value>Helló! Köszönjük, hogy az Auto Dark Mode alkalmazást használja. Hogy tetszik önnek eddig?
 
-Ez az alkalmazás kellemesebbé teszi mindennapjait, azáltal, hogy gondoskodik a szeméről. Ugyanakkor teljesen ingyenes, hirdetésmentes, nem gyűjt felhasználói adatokat és nyílt forráskódú.
-Ez a projekt nem hoz nekem semennyi hasznot.
+Ez az alkalmazás kellemesebbé teszi mindennapjait, azáltal, hogy gondoskodik a szeméről. Ugyanakkor teljesen ingyenes, hirdetésmentes, nem gyűjt felhasználói adatokat és nyílt forráskódú. Ez a projekt nem hoz nekem semennyi hasznot.
 
 Ebből kifolyólag támogathatna egy önkéntes adománnyal. Még egy kis összegtől is boldogan ugrálnék a lakásomban. Csak annyit adományozzon, amennyire ön értékeli a munkámat.</value>
   </data>
@@ -294,7 +294,7 @@ Ebből kifolyólag támogathatna egy önkéntes adománnyal. Még egy kis össze
     <value>Témaszín kapcsoló engedélyezése</value>
   </data>
   <data name="EnableAutoThemeSwitch" xml:space="preserve">
-    <value>Automatikus téma változtatás engedélyezése</value>
+    <value>Automatikus témaváltás engedélyezése</value>
   </data>
   <data name="EnableCursorSwitch" xml:space="preserve">
     <value>Egérkurzor váltás engedélyezése</value>
@@ -318,9 +318,7 @@ Kérem ellenőrizze az alábbiakat:
 - a szolgáltatás fut
 - a config.yaml fájl megfelelő
 
-Szeretne egy hibabejelentést tenni az Auto Dark Mode repository-n?
-Kattintson "Igen"-re egy új böngészőablak megnyitásához.
-</value>
+Szeretne egy hibabejelentést tenni az Auto Dark Mode repository-n?</value>
   </data>
   <data name="ErrorOccurred_Title" xml:space="preserve">
     <value>Hiba történt</value>
@@ -455,7 +453,7 @@ Kattintson "Igen"-re egy új böngészőablak megnyitásához.
     <value>Longitude</value>
   </data>
   <data name="ManagedMode" xml:space="preserve">
-    <value>Hagyja, hogy az Auto Dark Mode kezelje a témámat</value>
+    <value>Hagyja, hogy az Auto Dark Mode kezelje a témámat (ajánlott)</value>
   </data>
   <data name="Manual" xml:space="preserve">
     <value>Kézi</value>
@@ -494,7 +492,7 @@ Kattintson "Igen"-re egy új böngészőablak megnyitásához.
     <value>Frissítés letöltése</value>
   </data>
   <data name="Msg_IgnoreDisabled" xml:space="preserve">
-    <value>Ez a beállítás nem támogatja az alapértelmezett Windows-témákat</value>
+    <value>Ez a beállítás nem támogatja az előre telepítettWindows-témákat</value>
   </data>
   <data name="Msg_LocPerm" xml:space="preserve">
     <value>Ennek az alkalmazásnak szüksége van az ön tartózkodási helyéhez</value>
@@ -503,7 +501,7 @@ Kattintson "Igen"-re egy új böngészőablak megnyitásához.
     <value>A szolgáltatás még nem fut, kérjük, várjon…</value>
   </data>
   <data name="Msg_NoUpdate" xml:space="preserve">
-    <value>Nincsenek új frissítések.</value>
+    <value>Nincsenek új frissítések</value>
   </data>
   <data name="Msg_PauseOnce" xml:space="preserve">
     <value>A témaváltás egyszer szünetel!</value>
@@ -530,10 +528,7 @@ Kattintson "Igen"-re egy új böngészőablak megnyitásához.
     <value>Új frissítés érhető el!</value>
   </data>
   <data name="Msg_UpdaterText" xml:space="preserve">
-    <value>Köszönjük, hogy az Auto Dark Mode alkalmazást használja!
-
-Egy új verzió érhető el a GitHub-on javításokkal és fejlesztésekkel.
-Szeretné letölteni?
+    <value>Egy új verzió érhető el a GitHub-on javításokkal és fejlesztésekkel.
 
 Jelenleg telepített verzió: {0}, új verzió: {1}</value>
   </data>
@@ -541,7 +536,7 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
     <value>A verzióadatok a vágólapra másolva</value>
   </data>
   <data name="NextUpdateAt" xml:space="preserve">
-    <value>Next update at</value>
+    <value>Következő frissítés</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>None</value>
@@ -676,7 +671,7 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
     <value>Ne váltson, amíg bizonyos folyamatok futnak</value>
   </data>
   <data name="RefreshAutostart" xml:space="preserve">
-    <value>Automatikus indítás frissítése</value>
+    <value>Frissítés</value>
   </data>
   <data name="RegistryKey" xml:space="preserve">
     <value>Registry Kulcs</value>
@@ -870,152 +865,152 @@ Jelenleg telepített verzió: {0}, új verzió: {1}</value>
 2. Change the system color to 'Light' for the light theme.
 3. Go to Windows Settings &gt; Personalization &gt; Themes.
 4. Select your favorite wallpaper, mouse pointers and accent color.
-5. Save your theme.
-6. Repeat this process for the dark theme.</value>
+5. Mentse el a témáját.
+6. Ismételje meg a folyamatot a sötét témával.</value>
   </data>
   <data name="EditHotkey" xml:space="preserve">
-    <value>Edit hotkey</value>
+    <value>Gyorsbillentyű módosítása</value>
   </data>
   <data name="DisplayMonitorDisconnected" xml:space="preserve">
     <value>Nincs csatlakoztatva</value>
   </data>
   <data name="Background" xml:space="preserve">
-    <value>Background</value>
+    <value>Háttér</value>
     <comment>match Windows Settings</comment>
   </data>
   <data name="SelectColor" xml:space="preserve">
     <value>Select color</value>
   </data>
   <data name="DisableWindowsManagesTheme" xml:space="preserve">
-    <value>Disable Windows manages your theme</value>
+    <value>Windows témakezelésének letiltása</value>
   </data>
   <data name="Path" xml:space="preserve">
-    <value>Path</value>
+    <value>Út</value>
   </data>
   <data name="StartWithWindowsFailed_Content" xml:space="preserve">
     <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
   </data>
   <data name="Beta" xml:space="preserve">
-    <value>Beta</value>
+    <value>Béta</value>
   </data>
   <data name="DebugMode" xml:space="preserve">
-    <value>Debug mode</value>
+    <value>Debug mód</value>
   </data>
   <data name="EnterToApply" xml:space="preserve">
-    <value>Select Enter to apply</value>
+    <value>Nyomjon Enter-t az alkalmazáshoz</value>
   </data>
   <data name="Language" xml:space="preserve">
-    <value>Language</value>
+    <value>Nyelv</value>
   </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
-    <value>Go to Windows Spotlight settings</value>
+    <value>Menjen a Windows Reflektorfény beállításokhoz</value>
   </data>
   <data name="Stable" xml:space="preserve">
-    <value>Stable</value>
+    <value>Stab</value>
   </data>
   <data name="Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>Váltás</value>
   </data>
   <data name="ShowNotificationPostponeToggled" xml:space="preserve">
-    <value>Show notification when the automatic theme switch is paused</value>
+    <value>Értesítés megjelenítése az automatikus témaváltás szüneteltetésekor</value>
   </data>
   <data name="ShowNotificationAutomaticThemeToggled" xml:space="preserve">
-    <value>Show notification when toggling the automatic theme switch</value>
+    <value>Értesítés megjelenítése az automatikus témaváltáskor</value>
   </data>
   <data name="SelectTheKeyCombination" xml:space="preserve">
-    <value>Select a combination of keys. Only shortcuts that start with Windows key, Ctrl, Alt or Shift are valid.</value>
+    <value>Válasszon egy billentyűkombinációt. Csak azok a gyorsbillentyűk érvényesek, amelyek a Windows, Ctrl, Alt vagy Shift billentyűvel kezdődnek.</value>
   </data>
   <data name="ActivationShortcut" xml:space="preserve">
-    <value>Activation shortcut</value>
+    <value>Aktiválási gyorsbillentyű</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Save</value>
+    <value>Mentés</value>
   </data>
   <data name="ForceSaveSettings" xml:space="preserve">
-    <value>Force save</value>
+    <value>Mentés kényszerítése</value>
   </data>
   <data name="Msg_HotkeyProblem" xml:space="preserve">
-    <value>The hotkey didn't work? Don't worry, let's save it again</value>
+    <value>Nem működött a gyorsbillentyű? Ne aggódjon, mentsük el újra</value>
   </data>
   <data name="SaveSuccessfully" xml:space="preserve">
-    <value>Save successfully</value>
+    <value>Sikeres mentés</value>
   </data>
   <data name="SaveFailed" xml:space="preserve">
-    <value>Save failed</value>
+    <value>Sikertelen mentés</value>
   </data>
   <data name="AddApps" xml:space="preserve">
-    <value>Start typing to add any apps</value>
+    <value>Kezdjen gépelni bármely alkalmazás hozzáadásához</value>
   </data>
   <data name="AppMode" xml:space="preserve">
-    <value>App mode</value>
+    <value>Alkalmazás mód</value>
   </data>
   <data name="WindowsMode" xml:space="preserve">
-    <value>Windows mode</value>
+    <value>Windows mód</value>
   </data>
   <data name="WindowsColorsSetting" xml:space="preserve">
-    <value>Personalized colors setting of Windows</value>
+    <value>Windows személyre szabott színbeállításai</value>
   </data>
   <data name="Delayed" xml:space="preserve">
-    <value>Delayed</value>
+    <value>Késleltetve</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
-    <value>Not Delayed</value>
+    <value>Nincs késleltetve</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
-    <value>Ignore color</value>
+    <value>Szín figyelmen kívül hagyása</value>
   </data>
   <data name="AccentSurfaces" xml:space="preserve">
     <value>Accent Surfaces</value>
   </data>
   <data name="AccentSurfacesChoose" xml:space="preserve">
-    <value>Choose when the accent color should be applied</value>
+    <value>Válassza ki, hogy mikor legyen alkalmazva a témaszín</value>
   </data>
   <data name="ApplyDuring" xml:space="preserve">
-    <value>Apply during</value>
+    <value>Alkalmazás ez alatt</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Accent color for the taskbar during dark mode</value>
+    <value>Témaszín alkalmazása a tálcán sötét módban</value>
   </data>
   <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Accent color for title bars and window borders</value>
+    <value>Témaszín alkalmazása a fejléceken és ablakkereteken</value>
   </data>
   <data name="AggressiveDwmRefresh" xml:space="preserve">
-    <value>More aggressive DWM refresh</value>
+    <value>Agresszívebb DWM frissítés</value>
   </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
-    <value>Use aggressive DWM refresh?</value>
+    <value>Agresszív DWM frissítés alkalmazása?</value>
   </data>
   <data name="OffsetTime_Header" xml:space="preserve">
     <value>Delay switching by a number minutes</value>
   </data>
   <data name="OffsetTime_Description" xml:space="preserve">
-    <value>Positive values are later, negative values are earlier</value>
+    <value>Pozitív értékek később, negatív értékek korábban</value>
   </data>
   <data name="DarkModeForWebbrowser" xml:space="preserve">
-    <value>Dark mode for your web browser</value>
+    <value>Sötét mód a böngészőjéhez</value>
   </data>
   <data name="DarkModeForWebbrowserDescription" xml:space="preserve">
-    <value>Dark Reader is a browser extension which makes websites in Chrome, Edge and Firefox respect the current theme of your system. Click here to learn more</value>
+    <value>A Dark Reader egy böngészőbővítmény, amely a Chrome, Edge és Firefox böngészőkben a weboldalakat a rendszer aktuális témájához igazítja. Kattintson ide, ha többet szeretne megtudni</value>
   </data>
   <data name="WindowsMousePointerSetting" xml:space="preserve">
-    <value>Open Windows mouse pointer settings</value>
+    <value>Windows egérkurzor beállítások megnyitása</value>
   </data>
   <data name="WindowsMousePointerSettingDescription" xml:space="preserve">
-    <value>You can define new cursor schemes in the Windows settings and then select them here afterwards</value>
+    <value>Új kurzorsémákat a Windows beállításaiban hozhat létre, majd itt választhatja ki őket</value>
   </data>
   <data name="FitMode_Center" xml:space="preserve">
     <value>Center</value>
   </data>
   <data name="LogAndShell" xml:space="preserve">
-    <value>Log and Shell</value>
+    <value>Log és Shell</value>
   </data>
   <data name="Copied" xml:space="preserve">
-    <value>Copied</value>
+    <value>Másolva</value>
   </data>
   <data name="AggressiveDWMRefreshDescription" xml:space="preserve">
-    <value>Attempts to reduce wrong UI colors in the explorer, taskbar and start menu.</value>
+    <value>Megpróbálja csökkenteni a hibás felhasználói felület színeket a Fájlkezelőben, a tálcán és a Start menüben.</value>
   </data>
   <data name="OpenWindowsSettings" xml:space="preserve">
-    <value>Open Windows settings</value>
+    <value>Windows beállítások megnyitása</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/hu/Resources.resw
+++ b/AutoDarkModeApp/Strings/hu/Resources.resw
@@ -1018,9 +1018,6 @@ Ritka esetekben a Windows sípoló hangot adhat, amikor az egeret a DWM frissít
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/id/Resources.resw
+++ b/AutoDarkModeApp/Strings/id/Resources.resw
@@ -1018,9 +1018,6 @@ Pada kesempatan yang jarang terjadi, Windows dapat mengeluarkan suara bip ketika
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/it/Resources.resw
+++ b/AutoDarkModeApp/Strings/it/Resources.resw
@@ -1018,9 +1018,6 @@ In rare occasioni, Windows potrebbe emettere un segnale acustico quando si spost
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/ja/Resources.resw
+++ b/AutoDarkModeApp/Strings/ja/Resources.resw
@@ -1008,9 +1008,6 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/ko/Resources.resw
+++ b/AutoDarkModeApp/Strings/ko/Resources.resw
@@ -1018,9 +1018,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/nb-no/Resources.resw
+++ b/AutoDarkModeApp/Strings/nb-no/Resources.resw
@@ -1018,9 +1018,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/nl/Resources.resw
+++ b/AutoDarkModeApp/Strings/nl/Resources.resw
@@ -1018,9 +1018,6 @@ Heel soms kan Windows een piepgeluid afspelen wanneer de muis wordt bewogen tijd
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/pl/Resources.resw
+++ b/AutoDarkModeApp/Strings/pl/Resources.resw
@@ -1018,9 +1018,6 @@ W rzadkich przypadkach, Windows może wyemitować dźwięk "beep" jeśli mysz zo
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/pt-br/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-br/Resources.resw
@@ -1018,9 +1018,6 @@ Em ocasiões raras, o Windows pode emitir um som de bipe quando o mouse for movi
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/pt-pt/Resources.resw
+++ b/AutoDarkModeApp/Strings/pt-pt/Resources.resw
@@ -1018,9 +1018,6 @@ Em raras ocasiões, o Windows pode emitir um sinal sonoro quando o rato é movid
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/ro/Resources.resw
+++ b/AutoDarkModeApp/Strings/ro/Resources.resw
@@ -1018,9 +1018,6 @@ Poate introduce încetinire mică spre moderată pe anumite sisteme în timpul s
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/ru/Resources.resw
+++ b/AutoDarkModeApp/Strings/ru/Resources.resw
@@ -1018,9 +1018,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/sr/Resources.resw
+++ b/AutoDarkModeApp/Strings/sr/Resources.resw
@@ -1018,9 +1018,6 @@ U retkim slučajevima, Windows može izdati zvuk pištanja kad se miš pomera to
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/sv/Resources.resw
+++ b/AutoDarkModeApp/Strings/sv/Resources.resw
@@ -1018,9 +1018,6 @@ On rare occasions, Windows may emit a beeping sound when the mouse is moved duri
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/tr/Resources.resw
+++ b/AutoDarkModeApp/Strings/tr/Resources.resw
@@ -1018,9 +1018,6 @@ Nadir durumlarda, DWM yenilemeleri sırasında fare hareket ettirildiğinde Wind
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/uk/Resources.resw
+++ b/AutoDarkModeApp/Strings/uk/Resources.resw
@@ -1012,9 +1012,6 @@ Auto Dark Mode робить ваше повсякдення приємнішим
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/vi/Resources.resw
+++ b/AutoDarkModeApp/Strings/vi/Resources.resw
@@ -1018,9 +1018,6 @@ Trong một số trường hợp hiếm hoi, Windows có thể phát ra tiếng 
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/zh-hans/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hans/Resources.resw
@@ -147,9 +147,9 @@
   <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
     <value>尝试减少文件管理器、任务栏和开始菜单中错误 UI 颜色。如果你经常遇到这个问题或者被其困扰，请试着启用这个设置。
 
-这可能会在某些系统上引入轻到中度的主题切换延迟。
+在主题切换时，部分电脑可能会有轻到中度的卡顿。
 
-在极少数情况下，当鼠标在 DWM 刷新期间移动时，Windows 可能会发出蜂鸣声。</value>
+在极少数情况下，在 DWM 刷新期间移动鼠标时，Windows 可能会发出蜂鸣声。</value>
   </data>
   <data name="Apply" xml:space="preserve">
     <value>应用</value>
@@ -182,7 +182,7 @@
     <value>自动检查更新</value>
   </data>
   <data name="BatteryDarkMode" xml:space="preserve">
-    <value>未充电时切换至深色模式</value>
+    <value>使用电池时切换至深色模式</value>
   </data>
   <data name="BatteryPowered" xml:space="preserve">
     <value>电池设备</value>
@@ -441,10 +441,10 @@
     <value>位置信息</value>
   </data>
   <data name="LocationGeoService" xml:space="preserve">
-    <value>日出至日落（根据地理坐标）</value>
+    <value>日出日落（指定坐标）</value>
   </data>
   <data name="LocationService" xml:space="preserve">
-    <value>从日落到日出（位置服务）</value>
+    <value>日出日落（定位服务）</value>
   </data>
   <data name="LogonTask" xml:space="preserve">
     <value>使用登录任务而非启动项</value>
@@ -569,7 +569,7 @@
     <value>打开脚本设置</value>
   </data>
   <data name="OpenShell" xml:space="preserve">
-    <value>打开 shell</value>
+    <value>打开命令行</value>
   </data>
   <data name="OpenUpdaterLog" xml:space="preserve">
     <value>打开更新程序日志</value>
@@ -740,7 +740,7 @@
     <value>切换当前主题</value>
   </data>
   <data name="SwitchTouchKeyboard" xml:space="preserve">
-    <value>切换触摸键盘和输入</value>
+    <value>强制切换触摸键盘主题</value>
   </data>
   <data name="System" xml:space="preserve">
     <value>系统</value>
@@ -749,7 +749,7 @@
     <value>应用程序</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>任务</value>
+    <value>启动任务</value>
   </data>
   <data name="Theme" xml:space="preserve">
     <value>主题</value>
@@ -800,7 +800,7 @@
     <value>追踪模式</value>
   </data>
   <data name="Translator" xml:space="preserve">
-    <value>翻译者: zheolls、没有字的回音、ThrRip、shenzhiming88、Bill Lee</value>
+    <value>翻译者: zheolls、没有字的回音、ThrRip、shenzhiming88、Bill Lee、Kazuto Iris</value>
   </data>
   <data name="Type" xml:space="preserve">
     <value>类型</value>
@@ -878,7 +878,7 @@
     <value>路径</value>
   </data>
   <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>自动启动已在 Windows 设置中被禁用。 要使本程序再次随 Windows 系统一起启动,请前往Windows 设置 &gt; 应用 &gt; 启动并启用它。</value>
+    <value>自动启动已在 Windows 设置中被禁用。 要使本程序再次随 Windows 系统一起启动，请前往Windows 设置 &gt; 应用 &gt; 启动并启用它。</value>
   </data>
   <data name="Beta" xml:space="preserve">
     <value>测试版</value>
@@ -947,7 +947,7 @@
     <value>未推迟</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
-    <value>Ignore color</value>
+    <value>忽略颜色</value>
   </data>
   <data name="AccentSurfaces" xml:space="preserve">
     <value>强调色界面</value>
@@ -956,7 +956,7 @@
     <value>选择何时应用强调色</value>
   </data>
   <data name="ApplyDuring" xml:space="preserve">
-    <value>时段</value>
+    <value>在以下主题应用</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
     <value>深色模式下任务栏的强调色</value>
@@ -968,10 +968,10 @@
     <value>更激进的 DWM 刷新</value>
   </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
-    <value>使用激进的 DWM 刷新？</value>
+    <value>启用更激进的 DWM 刷新？</value>
   </data>
   <data name="OffsetTime_Header" xml:space="preserve">
-    <value>Delay switching by a number minutes</value>
+    <value>延迟切换（分钟）</value>
   </data>
   <data name="OffsetTime_Description" xml:space="preserve">
     <value>正值代表延后，负值表示提前</value>
@@ -980,7 +980,7 @@
     <value>Web 浏览器深色模式</value>
   </data>
   <data name="DarkModeForWebbrowserDescription" xml:space="preserve">
-    <value>Dark Reader 是一款浏览器扩展程序,它使 Chrome、Edge 和 Firefox 中的网站和当前系统的主题保持一致。 单击此处了解更多信息</value>
+    <value>Dark Reader 是一款浏览器扩展程序，它使 Chrome、Edge 和 Firefox 中的网站和当前系统的主题保持一致。 单击此处了解更多信息</value>
   </data>
   <data name="WindowsMousePointerSetting" xml:space="preserve">
     <value>打开 Windows 鼠标指针设置</value>
@@ -992,7 +992,7 @@
     <value>居中</value>
   </data>
   <data name="LogAndShell" xml:space="preserve">
-    <value>Log 和 Shell</value>
+    <value>日志和命令行</value>
   </data>
   <data name="Copied" xml:space="preserve">
     <value>已复制</value>

--- a/AutoDarkModeApp/Strings/zh-hans/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hans/Resources.resw
@@ -1002,9 +1002,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -145,10 +145,11 @@
     <value>總是淺色</value>
   </data>
   <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
-    <value>嘗試減少在檔案總管、工作列和開始功能表中出現錯誤介面顏色的頻率。 如果您經常遇到這種情況或受到困擾，請嘗試啟用此設定。
+    <value>嘗試減少在檔案總管、工作列和開始功能表中出現錯誤介面顏色的頻率。 如果你經常遇到這種情況或受到困擾，請嘗試啟用此設定。
 
 這可能會導致切換主題期間在系統造成部分輕微至中度的延遲，類似於在 Windows 10 中發生的情況。
-在極少數情況下，當重新啟動桌面視窗管理員（DWM）期間移動滑鼠時，Windows 可能會發出蜂鳴聲。</value>
+
+在極少數情況下，當重新整理 DWM 期間移動滑鼠時，Windows 可能會發出蜂鳴聲。</value>
   </data>
   <data name="Apply" xml:space="preserve">
     <value>套用</value>
@@ -163,13 +164,13 @@
     <value>自動</value>
   </data>
   <data name="AutomaticThemeSwitch" xml:space="preserve">
-    <value>啟用自動切換主題</value>
+    <value>開關自動主題切換</value>
   </data>
   <data name="AutoStart" xml:space="preserve">
     <value>自動啟動</value>
   </data>
   <data name="AutoSwitchGracePeriod" xml:space="preserve">
-    <value>通知等待使用者輸入的時間（分鐘）</value>
+    <value>通知的顯示時間（分鐘）</value>
   </data>
   <data name="AutoSwitchNotification" xml:space="preserve">
     <value>在自動切換主題前通知</value>
@@ -184,25 +185,25 @@
     <value>當裝置未連接電源時切換至深色模式</value>
   </data>
   <data name="BatteryPowered" xml:space="preserve">
-    <value>充電設備</value>
+    <value>由電池供電的裝置</value>
   </data>
   <data name="BlockedProcesses" xml:space="preserve">
-    <value>阻止中的處理程序</value>
+    <value>開始輸入以新增應用程式</value>
   </data>
   <data name="BrowsePhotos" xml:space="preserve">
-    <value>選擇檔案</value>
+    <value>瀏覽圖片</value>
   </data>
   <data name="Cancel" xml:space="preserve">
     <value>取消</value>
   </data>
   <data name="CheckUpdate" xml:space="preserve">
-    <value>檢查更新</value>
+    <value>立即檢查</value>
   </data>
   <data name="ChooseAFitForImage" xml:space="preserve">
-    <value>選擇適合您的桌面影像的大小</value>
+    <value>選擇適合你的桌面影像的大小</value>
   </data>
   <data name="ChooseWallpaper" xml:space="preserve">
-    <value>選擇您的背景</value>
+    <value>選擇你的背景</value>
   </data>
   <data name="City" xml:space="preserve">
     <value>城市</value>
@@ -214,16 +215,16 @@
     <value>色彩</value>
   </data>
   <data name="ColorFilter" xml:space="preserve">
-    <value>色彩濾鏡（發送按鍵 Win + Ctrl + C）</value>
+    <value>在深色模式下啟用色彩濾鏡</value>
   </data>
   <data name="ColorizationPick_Description" xml:space="preserve">
-    <value>根據您的喜好自訂 Windows 系統輔色方案。</value>
+    <value>根據你的喜好自訂 Windows 系統輔色方案。</value>
   </data>
   <data name="Conditions" xml:space="preserve">
     <value>條件</value>
   </data>
   <data name="Configuration" xml:space="preserve">
-    <value>設定檔</value>
+    <value>配置</value>
   </data>
   <data name="Confirm" xml:space="preserve">
     <value>確認</value>
@@ -232,13 +233,13 @@
     <value>複製</value>
   </data>
   <data name="CreateTheme" xml:space="preserve">
-    <value>建立您的佈景主題</value>
+    <value>建立你的佈景主題</value>
   </data>
   <data name="Cursors" xml:space="preserve">
-    <value>游標</value>
+    <value>滑鼠游標</value>
   </data>
   <data name="CustomHours" xml:space="preserve">
-    <value>設定自訂時間</value>
+    <value>自訂時間</value>
   </data>
   <data name="CustomScriptUserRepository" xml:space="preserve">
     <value>自訂指令碼的使用者儲存庫</value>
@@ -268,18 +269,17 @@
     <value>贊助</value>
   </data>
   <data name="Donation_Description" xml:space="preserve">
-    <value>您好！感謝您使用 Auto Dark Mode！到目前為止您喜歡此程式嗎？
+    <value>感謝你使用 Auto Dark Mode！到目前為止你喜歡此程式嗎？
 
-此程式透過自動調整色彩保護您的眼睛，讓您在使用電腦時更加舒適。同時完全免費、無廣告、不收集使用者資料，且開放原始碼。
-我不會從此程式獲得任何收益。
+此程式透過自動調整色彩保護你的眼睛，讓你在使用電腦時更加舒適。同時完全免費、無廣告、不收集使用者資料，且開放原始碼。我不會從此程式獲得任何收益。
 
-所以希望您能夠自願透過贊助來支持我。即使是一小筆錢也能使我在我的公寓裡開心地活蹦亂跳。只要贊助您覺得此程式在您心中值多少錢即可。</value>
+所以希望你能夠自願透過贊助來支持我。即使是一小筆錢也能使我在我的公寓裡開心地活蹦亂跳。只要贊助你覺得此程式在你心中值多少錢即可。</value>
   </data>
   <data name="DonationHowTo" xml:space="preserve">
     <value>如何贊助？</value>
   </data>
   <data name="DonationPayPal_Description" xml:space="preserve">
-    <value>您可以透過 PayPal 贊助我。這完全是自願的，您不應該期望任何賠償。</value>
+    <value>你可以透過 PayPal 贊助我。這完全是自願的，你不應該期望任何賠償。</value>
   </data>
   <data name="DonotSwitchGPUMonitoring" xml:space="preserve">
     <value>不要在遊玩遊戲時切換</value>
@@ -291,13 +291,13 @@
     <value>Edge（舊版）</value>
   </data>
   <data name="EnableAccentColorSwitch" xml:space="preserve">
-    <value>啟用輔色切換</value>
+    <value>切換輔色</value>
   </data>
   <data name="EnableAutoThemeSwitch" xml:space="preserve">
-    <value>啟用自動主題切換</value>
+    <value>自動切換主題</value>
   </data>
   <data name="EnableCursorSwitch" xml:space="preserve">
-    <value>啟用滑鼠游標切換</value>
+    <value>切換滑鼠游標</value>
   </data>
   <data name="EnableCustomScripts" xml:space="preserve">
     <value>啟用自訂指令碼</value>
@@ -306,30 +306,28 @@
     <value>已啟用</value>
   </data>
   <data name="EnableHotkeys" xml:space="preserve">
-    <value>啟用快速鍵</value>
+    <value>啟用快捷鍵</value>
   </data>
   <data name="EnableWallpaperSwitch" xml:space="preserve">
-    <value>啟用桌面背景切換</value>
+    <value>切換桌面背景</value>
   </data>
   <data name="ErrorMessageBox_Content" xml:space="preserve">
     <value>介面發生一些問題。
 
 請確保：
 - 服務正在執行
-- 您的 config.yaml 檔案是正確的
+- config.yaml 檔案是正確的
 
-您想在 Auto Dark Mode 儲存庫上建立問題嗎？
-點按「是」以開啟新的瀏覽器視窗。
-</value>
+你想在 Auto Dark Mode 儲存庫上建立問題嗎？</value>
   </data>
   <data name="ErrorOccurred_Title" xml:space="preserve">
     <value>發生錯誤</value>
   </data>
   <data name="FeatureDisabled_WhileManagedMode" xml:space="preserve">
-    <value>當 Auto Dark Mode 管理您的主題時，此功能會停用。</value>
+    <value>當 Auto Dark Mode 管理你的主題時，此功能會停用。</value>
   </data>
   <data name="FeatureDisabled_WhileThemeMode" xml:space="preserve">
-    <value>當 Windows 管理您的主題時，此功能會停用。</value>
+    <value>當 Windows 管理你的主題時，此功能會停用。</value>
   </data>
   <data name="FitMode_Fill" xml:space="preserve">
     <value>填滿</value>
@@ -356,13 +354,13 @@
     <value>強制淺色模式</value>
   </data>
   <data name="General" xml:space="preserve">
-    <value>設定</value>
+    <value>一般</value>
   </data>
   <data name="GeoCoordinates" xml:space="preserve">
     <value>地理座標</value>
   </data>
   <data name="GetCoordinates" xml:space="preserve">
-    <value>您所在位置的地理座標</value>
+    <value>你所在位置的地理座標</value>
   </data>
   <data name="GpuUsageDetectionSpeed" xml:space="preserve">
     <value>GPU 使用率偵測速度</value>
@@ -374,10 +372,10 @@
     <value>十六進制色碼</value>
   </data>
   <data name="HideTrayIcon" xml:space="preserve">
-    <value>隱藏系統匣圖示</value>
+    <value>隱藏系統匣圖示（不建議）</value>
   </data>
   <data name="Hotkeys" xml:space="preserve">
-    <value>快速鍵</value>
+    <value>快捷鍵</value>
   </data>
   <data name="IdleTime" xml:space="preserve">
     <value>系統空閒狀態判斷時間（分鐘）</value>
@@ -404,7 +402,7 @@
     <value>資訊</value>
   </data>
   <data name="InstallSilent" xml:space="preserve">
-    <value>不要顯示通知</value>
+    <value>無需進一步通知即可安裝</value>
   </data>
   <data name="Interval1" xml:space="preserve">
     <value>每天</value>
@@ -437,10 +435,10 @@
     <value>淺色主題</value>
   </data>
   <data name="Links" xml:space="preserve">
-    <value>連結</value>
+    <value>更多資訊</value>
   </data>
   <data name="LocationData" xml:space="preserve">
-    <value>位置資訊</value>
+    <value>位置</value>
   </data>
   <data name="LocationGeoService" xml:space="preserve">
     <value>從日落到日出（根據地理座標）</value>
@@ -455,7 +453,7 @@
     <value>經度</value>
   </data>
   <data name="ManagedMode" xml:space="preserve">
-    <value>以 Auto Dark Mode 管理我的主題</value>
+    <value>以 Auto Dark Mode 管理我的主題（建議）</value>
   </data>
   <data name="Manual" xml:space="preserve">
     <value>手動</value>
@@ -485,7 +483,7 @@
     <value>已儲存變更！</value>
   </data>
   <data name="Msg_ClickApply" xml:space="preserve">
-    <value>您的變更將會自動儲存。</value>
+    <value>你的變更將會自動儲存。</value>
   </data>
   <data name="Msg_DowngradeAvailable" xml:space="preserve">
     <value>有降級可用</value>
@@ -494,25 +492,25 @@
     <value>下載更新</value>
   </data>
   <data name="Msg_IgnoreDisabled" xml:space="preserve">
-    <value>此選項不支援預設的 Windows 佈景主題</value>
+    <value>此選項不支援預先安裝的預設 Windows 佈景主題</value>
   </data>
   <data name="Msg_LocPerm" xml:space="preserve">
-    <value>此程式需要存取您的位置</value>
+    <value>此程式需要存取你的位置</value>
   </data>
   <data name="Msg_NoService" xml:space="preserve">
     <value>服務尚未啟動，請稍候…</value>
   </data>
   <data name="Msg_NoUpdate" xml:space="preserve">
-    <value>已是最新版本。</value>
+    <value>未發現新更新</value>
   </data>
   <data name="Msg_PauseOnce" xml:space="preserve">
     <value>主題切換已暫停一次！</value>
   </data>
   <data name="Msg_PendingQuestion" xml:space="preserve">
-    <value>您想立即切換還是繼續延遲？</value>
+    <value>你想立即切換還是繼續延遲？</value>
   </data>
   <data name="Msg_SearchLoc" xml:space="preserve">
-    <value>正在取得您的位置…</value>
+    <value>正在取得你的位置…</value>
   </data>
   <data name="Msg_SearchUpdate" xml:space="preserve">
     <value>正在檢查更新…</value>
@@ -524,24 +522,21 @@
     <value>正在等待主題切換</value>
   </data>
   <data name="Msg_ThemeError" xml:space="preserve">
-    <value>警告：我們無法取得您目前的主題。</value>
+    <value>警告：我們無法取得你目前的主題。</value>
   </data>
   <data name="Msg_UpdateAvailable" xml:space="preserve">
     <value>有新版本可用！</value>
   </data>
   <data name="Msg_UpdaterText" xml:space="preserve">
-    <value>感謝您使用 Auto Dark Mode！
+    <value>在 GitHub 上有新版本，包含了修正及一些新功能。
 
-在 GitHub 上有新版本，包含了修正及一些新功能。
-您想要安裝嗎？
-
-目前版本：{0}，新版本：{1}</value>
+目前已安裝版本：{0}，新版本：{1}</value>
   </data>
   <data name="Msg_VersionInfoCopied" xml:space="preserve">
     <value>版本資訊已複製到剪貼簿</value>
   </data>
   <data name="NextUpdateAt" xml:space="preserve">
-    <value>下次更新時間</value>
+    <value>下次更新</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>無</value>
@@ -580,13 +575,13 @@
     <value>開啟更新工具記錄檔</value>
   </data>
   <data name="OpenWindowsNightLight" xml:space="preserve">
-    <value>開啟夜間光線設定</value>
+    <value>前往夜間光線設定</value>
   </data>
   <data name="PathAt" xml:space="preserve">
     <value>路徑：</value>
   </data>
   <data name="PauseAutoThemeSwitching" xml:space="preserve">
-    <value>暫停自動主題切換</value>
+    <value>開關暫停自動主題切換</value>
   </data>
   <data name="Personalization" xml:space="preserve">
     <value>個人化</value>
@@ -604,7 +599,7 @@
     <value>選擇主題</value>
   </data>
   <data name="PickTheme_Description" xml:space="preserve">
-    <value>分別為深色和淺色模式選擇不同的 Windows 主題。允許完整的自訂主題，但需要您自行設定 .theme 檔案。</value>
+    <value>分別為深色和淺色模式選擇不同的 Windows 主題。允許完整的自訂主題，但需要你自行設定 .theme 檔案。</value>
   </data>
   <data name="PickWallpaper" xml:space="preserve">
     <value>選擇桌面背景</value>
@@ -676,7 +671,7 @@
     <value>在特定處理程序正在執行時不要切換</value>
   </data>
   <data name="RefreshAutostart" xml:space="preserve">
-    <value>重新載入自動啟動</value>
+    <value>重新整理</value>
   </data>
   <data name="RegistryKey" xml:space="preserve">
     <value>登錄機碼</value>
@@ -706,13 +701,13 @@
     <value>僅恢復有設定到期時間的延遲</value>
   </data>
   <data name="SamplesFast" xml:space="preserve">
-    <value>快速（1 取樣）</value>
+    <value>快速（1 次取樣）</value>
   </data>
   <data name="SamplesMedium" xml:space="preserve">
-    <value>中等（2 取樣）</value>
+    <value>中等（2 次取樣）</value>
   </data>
   <data name="SamplesSlow" xml:space="preserve">
-    <value>緩慢（3 取樣）</value>
+    <value>緩慢（3 次取樣）</value>
   </data>
   <data name="Scripts" xml:space="preserve">
     <value>指令碼</value>
@@ -733,7 +728,7 @@
     <value>特別感謝</value>
   </data>
   <data name="StartWithWindows" xml:space="preserve">
-    <value>開機後自動開啟 Auto Dark Mode</value>
+    <value>Windows 啟動後自動啟動 Auto Dark Mode</value>
   </data>
   <data name="StopForcing" xml:space="preserve">
     <value>停止強制使用主題</value>
@@ -824,7 +819,7 @@
     <value>以 Windows 管理我的主題</value>
   </data>
   <data name="UpdateAtStart" xml:space="preserve">
-    <value>當 Auto Dark Mode 啟動時檢查更新</value>
+    <value>在 Auto Dark Mode 啟動時檢查</value>
   </data>
   <data name="UpdateChannel" xml:space="preserve">
     <value>選擇更新通道</value>
@@ -860,162 +855,162 @@
     <value>Windows 焦點</value>
   </data>
   <data name="Warning1903" xml:space="preserve">
-    <value>您的電腦尚未安裝 Windows 10 的 2019 年 4 月更新，因此已停用這個選項。</value>
+    <value>你的電腦尚未安裝 Windows 10 的 2019 年 4 月更新，因此已停用這個選項。</value>
   </data>
   <data name="WindowsAutostartDisabled" xml:space="preserve">
-    <value>您已透過 Windows 停用自動啟動。</value>
+    <value>你已透過 Windows 停用自動啟動。</value>
   </data>
   <data name="ThemeTutorialDescription" xml:space="preserve">
-    <value>1. Go to Windows Settings &gt; Personalization &gt; Colors.
-2. Change the system color to 'Light' for the light theme.
-3. Go to Windows Settings &gt; Personalization &gt; Themes.
-4. Select your favorite wallpaper, mouse pointers and accent color.
-5. Save your theme.
-6. Repeat this process for the dark theme.</value>
+    <value>1. 前往 Windows 設定 &gt; 個人化 &gt; 色彩。
+2. 將系統顏色變更為「淺色」以啟用淺色主題。
+3. 前往 Windows 設定 &gt; 個人化 &gt; 佈景主題。
+4. 選擇你喜歡的背景、滑鼠游標和輔色。
+5. 儲存你的主題。
+6. 對深色主題重複此過程。</value>
   </data>
   <data name="EditHotkey" xml:space="preserve">
-    <value>Edit hotkey</value>
+    <value>編輯快捷鍵</value>
   </data>
   <data name="DisplayMonitorDisconnected" xml:space="preserve">
     <value>已中斷連結</value>
   </data>
   <data name="Background" xml:space="preserve">
-    <value>Background</value>
+    <value>背景</value>
     <comment>match Windows Settings</comment>
   </data>
   <data name="SelectColor" xml:space="preserve">
     <value>Select color</value>
   </data>
   <data name="DisableWindowsManagesTheme" xml:space="preserve">
-    <value>Disable Windows manages your theme</value>
+    <value>停用 Windows 管理你的主題</value>
   </data>
   <data name="Path" xml:space="preserve">
-    <value>Path</value>
+    <value>路徑</value>
   </data>
   <data name="StartWithWindowsFailed_Content" xml:space="preserve">
-    <value>Auto start has been disabled via the Task Manager "Startup Apps" tab. If you would like Auto Dark Mode to start with Windows again, please re-enable it there.</value>
+    <value>Windows 設定中的自動啟動功能已被停用。若要再次於 Windows 啟動時自動啟動 Auto Dark Mode，請前往 Windows 設定 &gt; 應用程式 &gt; 啟動，並啟用它。</value>
   </data>
   <data name="Beta" xml:space="preserve">
-    <value>Beta</value>
+    <value>測試版</value>
   </data>
   <data name="DebugMode" xml:space="preserve">
-    <value>Debug mode</value>
+    <value>偵錯模式</value>
   </data>
   <data name="EnterToApply" xml:space="preserve">
-    <value>Select Enter to apply</value>
+    <value>按 Enter 以套用</value>
   </data>
   <data name="Language" xml:space="preserve">
-    <value>Language</value>
+    <value>語言</value>
   </data>
   <data name="OpenWindowsSpotlight" xml:space="preserve">
-    <value>Go to Windows Spotlight settings</value>
+    <value>前往 Windows 焦點設定</value>
   </data>
   <data name="Stable" xml:space="preserve">
-    <value>Stable</value>
+    <value>穩定版</value>
   </data>
   <data name="Switch" xml:space="preserve">
-    <value>Switch</value>
+    <value>切換</value>
   </data>
   <data name="ShowNotificationPostponeToggled" xml:space="preserve">
-    <value>Show notification when the automatic theme switch is paused</value>
+    <value>自動主題切換暫停時顯示通知</value>
   </data>
   <data name="ShowNotificationAutomaticThemeToggled" xml:space="preserve">
-    <value>Show notification when toggling the automatic theme switch</value>
+    <value>開關自動主題切換時顯示通知</value>
   </data>
   <data name="SelectTheKeyCombination" xml:space="preserve">
-    <value>Select a combination of keys. Only shortcuts that start with Windows key, Ctrl, Alt or Shift are valid.</value>
+    <value>選擇組合鍵。僅以 Windows 鍵、Ctrl、Alt 或 Shift 開頭的快捷鍵有效。</value>
   </data>
   <data name="ActivationShortcut" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Save</value>
+    <value>儲存</value>
   </data>
   <data name="ForceSaveSettings" xml:space="preserve">
-    <value>Force save</value>
+    <value>強制儲存</value>
   </data>
   <data name="Msg_HotkeyProblem" xml:space="preserve">
-    <value>The hotkey didn't work? Don't worry, let's save it again</value>
+    <value>快捷鍵無法作用了？別擔心，我們再儲存一次</value>
   </data>
   <data name="SaveSuccessfully" xml:space="preserve">
-    <value>Save successfully</value>
+    <value>儲存成功</value>
   </data>
   <data name="SaveFailed" xml:space="preserve">
-    <value>Save failed</value>
+    <value>儲存失敗</value>
   </data>
   <data name="AddApps" xml:space="preserve">
-    <value>Start typing to add any apps</value>
+    <value>開始輸入以新增任何應用程式</value>
   </data>
   <data name="AppMode" xml:space="preserve">
-    <value>App mode</value>
+    <value>應用程式模式</value>
   </data>
   <data name="WindowsMode" xml:space="preserve">
-    <value>Windows mode</value>
+    <value>Windows 模式</value>
   </data>
   <data name="WindowsColorsSetting" xml:space="preserve">
-    <value>Personalized colors setting of Windows</value>
+    <value>Windows 個人化顏色設定</value>
   </data>
   <data name="Delayed" xml:space="preserve">
-    <value>Delayed</value>
+    <value>已延遲</value>
   </data>
   <data name="NotDelayed" xml:space="preserve">
-    <value>Not Delayed</value>
+    <value>未延遲</value>
   </data>
   <data name="IgnoreColor" xml:space="preserve">
-    <value>Ignore color</value>
+    <value>忽略顏色</value>
   </data>
   <data name="AccentSurfaces" xml:space="preserve">
     <value>Accent Surfaces</value>
   </data>
   <data name="AccentSurfacesChoose" xml:space="preserve">
-    <value>Choose when the accent color should be applied</value>
+    <value>選擇何時套用輔色</value>
   </data>
   <data name="ApplyDuring" xml:space="preserve">
-    <value>Apply during</value>
+    <value>套用時段</value>
   </data>
   <data name="AccentApplyTaskbar" xml:space="preserve">
-    <value>Accent color for the taskbar during dark mode</value>
+    <value>深色模式下工作列的輔色</value>
   </data>
   <data name="AccentApplyTitlebarAndBorders" xml:space="preserve">
-    <value>Accent color for title bars and window borders</value>
+    <value>標題列和視窗邊框的輔色</value>
   </data>
   <data name="AggressiveDwmRefresh" xml:space="preserve">
-    <value>More aggressive DWM refresh</value>
+    <value>更積極的 DWM 重新整理</value>
   </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
-    <value>Use aggressive DWM refresh?</value>
+    <value>使用積極的 DWM 重新整理？</value>
   </data>
   <data name="OffsetTime_Header" xml:space="preserve">
     <value>Delay switching by a number minutes</value>
   </data>
   <data name="OffsetTime_Description" xml:space="preserve">
-    <value>Positive values are later, negative values are earlier</value>
+    <value>正值表示延後，負值表示提前</value>
   </data>
   <data name="DarkModeForWebbrowser" xml:space="preserve">
-    <value>Dark mode for your web browser</value>
+    <value>為你的網路瀏覽器套用深色模式</value>
   </data>
   <data name="DarkModeForWebbrowserDescription" xml:space="preserve">
-    <value>Dark Reader is a browser extension which makes websites in Chrome, Edge and Firefox respect the current theme of your system. Click here to learn more</value>
+    <value>Dark Reader 是一個瀏覽器擴充功能，可以讓 Chrome、Edge 和 Firefox 中的網站跟隨系統目前主題。點擊此處以瞭解更多</value>
   </data>
   <data name="WindowsMousePointerSetting" xml:space="preserve">
-    <value>Open Windows mouse pointer settings</value>
+    <value>開啟 Windows 滑鼠指標設定</value>
   </data>
   <data name="WindowsMousePointerSettingDescription" xml:space="preserve">
-    <value>You can define new cursor schemes in the Windows settings and then select them here afterwards</value>
+    <value>你可以在 Windows 設定中定義新的游標方案，然後在此處選擇它們</value>
   </data>
   <data name="FitMode_Center" xml:space="preserve">
-    <value>Center</value>
+    <value>居中</value>
   </data>
   <data name="LogAndShell" xml:space="preserve">
-    <value>Log and Shell</value>
+    <value>Log 和 Shell</value>
   </data>
   <data name="Copied" xml:space="preserve">
-    <value>Copied</value>
+    <value>已複製</value>
   </data>
   <data name="AggressiveDWMRefreshDescription" xml:space="preserve">
-    <value>Attempts to reduce wrong UI colors in the explorer, taskbar and start menu.</value>
+    <value>嘗試減少檔案總管、工作列和開始功能表中錯誤的介面顏色。</value>
   </data>
   <data name="OpenWindowsSettings" xml:space="preserve">
-    <value>Open Windows settings</value>
+    <value>開啟 Windows 設定</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -986,12 +986,6 @@
   <data name="OffsetTime_Description" xml:space="preserve">
     <value>正值表示延後，負值表示提前</value>
   </data>
-  <data name="AlwaysRefreshDwmMsg_Content" xml:space="preserve">
-    <value>嘗試減少在檔案總管、工作列和開始功能表中出現錯誤介面顏色的頻率。 如果您經常遇到這種情況或受到困擾，請嘗試啟用此設定。
-
-這可能會導致切換主題期間在系統造成部分輕微至中度的延遲，類似於在 Windows 10 中發生的情況。
-在極少數情況下，當重新啟動桌面視窗管理員（DWM）期間移動滑鼠時，Windows 可能會發出蜂鳴聲。</value>
-  </data>
   <data name="AggressiveDwmRefreshMsg_Title" xml:space="preserve">
     <value>Use aggressive DWM refresh?</value>
   </data>

--- a/AutoDarkModeApp/Strings/zh-hant/Resources.resw
+++ b/AutoDarkModeApp/Strings/zh-hant/Resources.resw
@@ -1018,9 +1018,6 @@
   <data name="OpenWindowsSettings" xml:space="preserve">
     <value>Open Windows settings</value>
   </data>
-  <data name="HotkeyInfoBarMessage" xml:space="preserve">
-    <value>Hotkeys can only be changed while disabled</value>
-  </data>
   <data name="SelectedColor" xml:space="preserve">
     <value>Currently selected color</value>
   </data>

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml
@@ -8,10 +8,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel
-        Orientation="Vertical"
-        PreviewKeyDown="StackPanel_PreviewKeyDown"
-        Spacing="16">
+    <StackPanel Orientation="Vertical" Spacing="16">
+
         <TextBlock Text="{helpers:ResourceString Name=SelectTheKeyCombination}" TextWrapping="Wrap" />
 
         <ItemsControl
@@ -45,6 +43,7 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
+
     </StackPanel>
 
 </UserControl>

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.WinUI;
+﻿using AutoDarkModeLib;
+using CommunityToolkit.WinUI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls;
 using Windows.System;
@@ -11,10 +12,6 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     [GeneratedDependencyProperty]
     public partial List<SingleHotkeyDataObject>? HotkeyCombination { get; set; }
 
-    // For developers:
-    // With regard to hotkeys, the storage format is: "Decorative key code, primary key code"
-    // Modifier key marks: Control=2, Shift=4, Alt=1, Win=8 (can be bitwise or combined)
-    // In Builder, they looks like: "ForceLight": "6,112"
     [GeneratedDependencyProperty]
     public partial string? CapturedHotkeys { get; set; }
 
@@ -27,15 +24,17 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             return;
         }
 
-        var parts = hotkeyString.Split(',');
-        if (parts.Length != 2 || !uint.TryParse(parts[0], out uint modifiers) || !uint.TryParse(parts[1], out uint keyCode))
+        var parsed = HotkeyStringConverter.Parse(hotkeyString);
+        if (parsed == null)
         {
             HotkeyCombination = null;
             CapturedHotkeys = null;
             return;
         }
 
-        CapturedHotkeys = hotkeyString;
+        var (modifiers, keyCode) = parsed.Value;
+
+        CapturedHotkeys = HotkeyStringConverter.ToDisplayFormat(hotkeyString);
 
         List<string> displayParts = [];
         if ((modifiers & 2) != 0)
@@ -54,7 +53,7 @@ public sealed partial class ShortcutDialogContentControl : UserControl
         {
             displayParts.Add("Win");
         }
-        displayParts.Add(GetKeyDisplayName((VirtualKey)keyCode));
+        displayParts.Add(HotkeyStringConverter.GetKeyDisplayName((VirtualKey)keyCode));
 
         HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
     }
@@ -85,30 +84,6 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             return;
         }
 
-        // MOD_ALT = 0x0001
-        // MOD_CONTROL = 0x0002
-        // MOD_SHIFT = 0x0004
-        // MOD_WIN = 0x0008
-        uint modifiers = 0;
-        if (isAlt)
-        {
-            modifiers |= 1;
-        }
-        if (isCtrl)
-        {
-            modifiers |= 2;
-        }
-        if (isShift)
-        {
-            modifiers |= 4;
-        }
-        if (isWin)
-        {
-            modifiers |= 8;
-        }
-
-        CapturedHotkeys = $"{modifiers},{(uint)key}";
-
         List<string> displayParts = [];
         if (isCtrl)
         {
@@ -129,8 +104,10 @@ public sealed partial class ShortcutDialogContentControl : UserControl
 
         if (!IsModifierKey(key))
         {
-            displayParts.Add(GetKeyDisplayName(key));
+            displayParts.Add(HotkeyStringConverter.GetKeyDisplayName(key));
         }
+
+        CapturedHotkeys = string.Join(" + ", displayParts);
 
         HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
 
@@ -141,33 +118,6 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     {
         var keyboardState = InputKeyboardSource.GetKeyStateForCurrentThread(key);
         return keyboardState.HasFlag(CoreVirtualKeyStates.Down);
-    }
-
-    private static string GetKeyDisplayName(VirtualKey key)
-    {
-        return key switch
-        {
-            VirtualKey.Enter => "Enter",
-            VirtualKey.Escape => "Esc",
-            VirtualKey.Space => "Space",
-            VirtualKey.Back => "Backspace",
-            VirtualKey.Delete => "Del",
-            VirtualKey.PageUp => "PgUp",
-            VirtualKey.PageDown => "PgDn",
-            VirtualKey.CapitalLock => "CapsLock",
-            (VirtualKey)188 => ",",
-            (VirtualKey)190 => ".",
-            (VirtualKey)191 => "/",
-            (VirtualKey)187 => "=",
-            (VirtualKey)189 => "-",
-            (VirtualKey)219 => "[",
-            (VirtualKey)221 => "]",
-            (VirtualKey)220 => "\\",
-            (VirtualKey)186 => ";",
-            (VirtualKey)222 => "'",
-            (VirtualKey)192 => "`",
-            _ => key.ToString(),
-        };
     }
 
     private static bool IsModifierKey(VirtualKey key)

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -15,47 +15,18 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     [GeneratedDependencyProperty]
     public partial string? CapturedHotkeys { get; set; }
 
-    public void LoadFromConfig(string? hotkeyString)
+    public void LoadFromKeyValue(string? hotkeyValue)
     {
-        if (string.IsNullOrEmpty(hotkeyString))
+        if (string.IsNullOrWhiteSpace(hotkeyValue))
         {
             HotkeyCombination = null;
             CapturedHotkeys = null;
             return;
         }
 
-        var parsed = HotkeyStringConverter.Parse(hotkeyString);
-        if (parsed == null)
-        {
-            HotkeyCombination = null;
-            CapturedHotkeys = null;
-            return;
-        }
-
-        var (modifiers, keyCode) = parsed.Value;
-
-        CapturedHotkeys = HotkeyStringConverter.ToDisplayFormat(hotkeyString);
-
-        List<string> displayParts = [];
-        if ((modifiers & 2) != 0)
-        {
-            displayParts.Add("Ctrl");
-        }
-        if ((modifiers & 4) != 0)
-        {
-            displayParts.Add("Shift");
-        }
-        if ((modifiers & 1) != 0)
-        {
-            displayParts.Add("Alt");
-        }
-        if ((modifiers & 8) != 0)
-        {
-            displayParts.Add("Win");
-        }
-        displayParts.Add(HotkeyStringConverter.GetKeyDisplayName((VirtualKey)keyCode));
-
-        HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
+        CapturedHotkeys = HotkeyStringConverter.ToDisplayFormat(hotkeyValue);
+        var displayParts = hotkeyValue.Split('+', StringSplitOptions.TrimEntries);
+        HotkeyCombination = displayParts.Select(part => new SingleHotkeyDataObject { Key = part }).ToList();
     }
 
     public ShortcutDialogContentControl()

--- a/AutoDarkModeApp/Utils/KeyboardHook.cs
+++ b/AutoDarkModeApp/Utils/KeyboardHook.cs
@@ -1,0 +1,125 @@
+﻿using System.Runtime.InteropServices;
+using Windows.System;
+
+namespace AutoDarkModeApp.Utils;
+
+public partial class KeyboardHook : IDisposable
+{
+    private const int WH_KEYBOARD_LL = 13;
+    private const int WM_KEYDOWN = 0x0100;
+    private const int WM_KEYUP = 0x0101;
+    private const int WM_SYSKEYDOWN = 0x0104;
+    private const int WM_SYSKEYUP = 0x0105;
+
+    private IntPtr _hookHandle = IntPtr.Zero;
+    private LowLevelKeyboardProc? _hookCallback;
+    private readonly Dictionary<VirtualKey, bool> _keyStates = [];
+
+    public event EventHandler<KeyboardHookEventArgs>? KeyEvent;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern short GetKeyState(int nVirtKey);
+
+    private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KBDLLHOOKSTRUCT
+    {
+        public int vkCode;
+        public int scanCode;
+        public int flags;
+        public int time;
+        public IntPtr dwExtraInfo;
+    }
+
+    public void Install()
+    {
+        if (_hookHandle == IntPtr.Zero)
+        {
+            _hookCallback = HookCallback;
+            _hookHandle = SetWindowsHookEx(WH_KEYBOARD_LL, _hookCallback, 0, 0);
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    public void Uninstall()
+    {
+        if (_hookHandle != IntPtr.Zero)
+        {
+            if (UnhookWindowsHookEx(_hookHandle))
+            {
+                _hookHandle = IntPtr.Zero;
+            }
+        }
+        _keyStates.Clear();
+    }
+
+    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0)
+        {
+            var kbd = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+            var key = (VirtualKey)kbd.vkCode;
+            var isKeyUp = wParam == (IntPtr)WM_KEYUP || wParam == (IntPtr)WM_SYSKEYUP;
+
+            _keyStates[key] = !isKeyUp;
+
+            var args = new KeyboardHookEventArgs
+            {
+                VirtualKeyCode = kbd.vkCode,
+                IsKeyUp = isKeyUp,
+                Handled = false
+            };
+
+            KeyEvent?.Invoke(this, args);
+
+            if (args.Handled)
+            {
+                return (IntPtr)1;
+            }
+        }
+
+        return CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+    }
+
+    public bool IsKeyDown(VirtualKey key)
+    {
+        if (_keyStates.TryGetValue(key, out bool state))
+        {
+            return state;
+        }
+
+        return (GetKeyState((int)key) & 0x8000) != 0;
+    }
+
+    public void Dispose()
+    {
+        Uninstall();
+        GC.SuppressFinalize(this);
+    }
+
+    public KeyboardHook()
+    {
+        Dispose();
+    }
+}
+
+public class KeyboardHookEventArgs : EventArgs
+{
+    public int VirtualKeyCode { get; set; }
+    public bool IsKeyUp { get; set; }
+    public bool Handled { get; set; }
+}

--- a/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
@@ -122,6 +122,8 @@ public partial class HotkeysViewModel : ObservableRecipient
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "HotkeysViewModel");
         }
 
+        MigrateWinFormsFormat();
+
         LoadSettings();
         LoadHotkeysList();
 
@@ -179,6 +181,53 @@ public partial class HotkeysViewModel : ObservableRecipient
             _builder.Load();
             _dispatcherQueue.TryEnqueue(() => LoadSettings());
             StateUpdateHandler.StartConfigWatcher();
+        }
+    }
+
+    private void MigrateWinFormsFormat()
+    {
+        bool needsSave = false;
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.ForceLight))
+        {
+            _builder.Config.Hotkeys.ForceLight = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.ForceLight);
+            needsSave = true;
+        }
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.ForceDark))
+        {
+            _builder.Config.Hotkeys.ForceDark = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.ForceDark);
+            needsSave = true;
+        }
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.NoForce))
+        {
+            _builder.Config.Hotkeys.NoForce = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.NoForce);
+            needsSave = true;
+        }
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.ToggleTheme))
+        {
+            _builder.Config.Hotkeys.ToggleTheme = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.ToggleTheme);
+            needsSave = true;
+        }
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.ToggleAutoThemeSwitch))
+        {
+            _builder.Config.Hotkeys.ToggleAutoThemeSwitch = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.ToggleAutoThemeSwitch);
+            needsSave = true;
+        }
+
+        if (HotkeyStringConverter.IsWinFormsFormat(_builder.Config.Hotkeys.TogglePostpone))
+        {
+            _builder.Config.Hotkeys.TogglePostpone = HotkeyStringConverter.ToDisplayFormat(_builder.Config.Hotkeys.TogglePostpone);
+            needsSave = true;
+        }
+
+        if (needsSave)
+        {
+            _skipConfigUpdate = true;
+            _builder.Save();
         }
     }
 

--- a/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
@@ -1,5 +1,10 @@
-﻿using AutoDarkModeApp.Contracts.Services;
+﻿using System.Collections.ObjectModel;
+using AutoDarkModeApp.Contracts.Services;
+using AutoDarkModeApp.Helpers;
+using AutoDarkModeApp.Models;
+using AutoDarkModeApp.Utils.Handlers;
 using AutoDarkModeLib;
+using AutoDarkModeLib.Configs;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AutoDarkModeApp.ViewModels;
@@ -7,8 +12,10 @@ namespace AutoDarkModeApp.ViewModels;
 public partial class HotkeysViewModel : ObservableRecipient
 {
     private readonly AdmConfigBuilder _builder = AdmConfigBuilder.Instance();
+    private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue;
     private readonly IErrorService _errorService;
     private bool _isInitializing;
+    private bool _skipConfigUpdate;
 
     [ObservableProperty]
     public partial bool HotkeysEnabled { get; set; }
@@ -19,14 +26,96 @@ public partial class HotkeysViewModel : ObservableRecipient
     [ObservableProperty]
     public partial bool HotkeyTogglePostponeNotificationEnabled { get; set; }
 
+    [ObservableProperty]
+    public partial ObservableCollection<HotkeysDataObject>? HotkeysCollection { get; set; }
+
+    public AdmConfig GetAdmConfig()
+    {
+        return _builder.Config;
+    }
+
+    public void SafeSaveBuilder()
+    {
+        try
+        {
+            _skipConfigUpdate = true;
+            _builder.Save();
+        }
+        catch (Exception ex)
+        {
+            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "HotkeysViewModel");
+        }
+    }
+
+    public void ForceSaveHotkeysSettings()
+    {
+        if (HotkeysCollection is not null)
+        {
+            _builder.Config.Hotkeys.ForceLight = HotkeysCollection.FirstOrDefault(h => h.Tag == "ForceLight")?.Keys;
+            _builder.Config.Hotkeys.ForceDark = HotkeysCollection.FirstOrDefault(h => h.Tag == "ForceDark")?.Keys;
+            _builder.Config.Hotkeys.NoForce = HotkeysCollection.FirstOrDefault(h => h.Tag == "StopForcing")?.Keys;
+            _builder.Config.Hotkeys.ToggleTheme = HotkeysCollection.FirstOrDefault(h => h.Tag == "ToggleTheme")?.Keys;
+            _builder.Config.Hotkeys.ToggleAutoThemeSwitch = HotkeysCollection.FirstOrDefault(h => h.Tag == "AutomaticThemeSwitch")?.Keys;
+            _builder.Config.Hotkeys.TogglePostpone = HotkeysCollection.FirstOrDefault(h => h.Tag == "PauseAutoThemeSwitching")?.Keys;
+        }
+    }
+
+    public string? GetHotkeyValue(string tag)
+    {
+        return tag switch
+        {
+            "ForceLight" => _builder.Config.Hotkeys.ForceLight,
+            "ForceDark" => _builder.Config.Hotkeys.ForceDark,
+            "StopForcing" => _builder.Config.Hotkeys.NoForce,
+            "ToggleTheme" or "AutomaticThemeSwitch" => _builder.Config.Hotkeys.ToggleAutoThemeSwitch,
+            "PauseAutoThemeSwitching" => _builder.Config.Hotkeys.TogglePostpone,
+            _ => null,
+        };
+    }
+
+    public void UpdateHotkeyValue(string tag, string? value)
+    {
+        if (HotkeysCollection is null)
+        {
+            return;
+        }
+
+        switch (tag)
+        {
+            case "ForceLight":
+                _builder.Config.Hotkeys.ForceLight = value;
+                break;
+            case "ForceDark":
+                _builder.Config.Hotkeys.ForceDark = value;
+                break;
+            case "StopForcing":
+                _builder.Config.Hotkeys.NoForce = value;
+                break;
+            case "ToggleTheme":
+                _builder.Config.Hotkeys.ToggleTheme = value;
+                break;
+            case "AutomaticThemeSwitch":
+                _builder.Config.Hotkeys.ToggleAutoThemeSwitch = value;
+                break;
+            case "PauseAutoThemeSwitching":
+                _builder.Config.Hotkeys.TogglePostpone = value;
+                break;
+        }
+
+        var item = HotkeysCollection.FirstOrDefault(h => h.Tag == tag);
+        item!.Keys = value;
+
+        SafeSaveBuilder();
+    }
+
     public HotkeysViewModel(IErrorService errorService)
     {
+        _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         _errorService = errorService;
 
         try
         {
             _builder.Load();
-            _builder.LoadLocationData();
         }
         catch (Exception ex)
         {
@@ -34,6 +123,10 @@ public partial class HotkeysViewModel : ObservableRecipient
         }
 
         LoadSettings();
+        LoadHotkeysList();
+
+        StateUpdateHandler.OnConfigUpdate += HandleConfigUpdate;
+        StateUpdateHandler.StartConfigWatcher();
     }
 
     private void LoadSettings()
@@ -47,52 +140,81 @@ public partial class HotkeysViewModel : ObservableRecipient
         _isInitializing = false;
     }
 
+    private void LoadHotkeysList()
+    {
+        var hotkeyConfigs = new[]
+        {
+            new { NameKey = "ForceLight", ConfigKey = nameof(Hotkeys.ForceLight) },
+            new { NameKey = "ForceDark", ConfigKey = nameof(Hotkeys.ForceDark) },
+            new { NameKey = "StopForcing", ConfigKey = nameof(Hotkeys.NoForce) },
+            new { NameKey = "ToggleTheme", ConfigKey = nameof(Hotkeys.ToggleTheme) },
+            new { NameKey = "AutomaticThemeSwitch", ConfigKey = nameof(Hotkeys.ToggleAutoThemeSwitch) },
+            new { NameKey = "PauseAutoThemeSwitching", ConfigKey = nameof(Hotkeys.TogglePostpone) },
+        };
+
+        HotkeysCollection = new ObservableCollection<HotkeysDataObject>(
+            hotkeyConfigs.Select(cfg =>
+            {
+                var propertyInfo = typeof(Hotkeys).GetProperty(cfg.ConfigKey) ?? throw new InvalidOperationException($"Property '{cfg.ConfigKey}' not found on type 'Hotkeys'.");
+                return new HotkeysDataObject
+                {
+                    DisplayName = cfg.NameKey.GetLocalized(),
+                    Keys = (string?)propertyInfo.GetValue(_builder.Config.Hotkeys),
+                    Tag = cfg.NameKey,
+                };
+            })
+        );
+    }
+
+    private void HandleConfigUpdate(object sender, FileSystemEventArgs e)
+    {
+        StateUpdateHandler.StopConfigWatcher();
+        if (_skipConfigUpdate)
+        {
+            _skipConfigUpdate = false;
+            StateUpdateHandler.StartConfigWatcher();
+        }
+        else
+        {
+            _builder.Load();
+            _dispatcherQueue.TryEnqueue(() => LoadSettings());
+            StateUpdateHandler.StartConfigWatcher();
+        }
+    }
+
     partial void OnHotkeysEnabledChanged(bool value)
     {
         if (_isInitializing)
+        {
             return;
+        }
 
         _builder.Config.Hotkeys.Enabled = value;
 
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "HotkeysViewModel");
-        }
+        SafeSaveBuilder();
     }
 
     partial void OnHotkeyToggleAutomaticThemeNotificationEnabledChanged(bool value)
     {
         if (_isInitializing)
+        {
             return;
+        }
 
         _builder.Config.Notifications.OnAutoThemeSwitching = value;
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "HotkeysViewModel");
-        }
+
+        SafeSaveBuilder();
     }
 
     partial void OnHotkeyTogglePostponeNotificationEnabledChanged(bool value)
     {
         if (_isInitializing)
+        {
             return;
+        }
 
         _builder.Config.Notifications.OnSkipNextSwitch = value;
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "HotkeysViewModel");
-        }
+
+        SafeSaveBuilder();
     }
 }

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml
@@ -62,7 +62,7 @@
                                     <TextBox
                                         MinWidth="160"
                                         IsReadOnly="True"
-                                        Text="{x:Bind Keys, Mode=OneWay}" />
+                                        Text="{x:Bind DisplayKeys, Mode=OneWay}" />
                                     <Button
                                         Width="32"
                                         Height="32"

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml
@@ -9,9 +9,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:AutoDarkModeApp.Models"
     mc:Ignorable="d">
-    <Page.Resources>
-        <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
-    </Page.Resources>
 
     <ScrollViewer>
         <Grid x:Name="ContentArea">
@@ -52,7 +49,7 @@
 
                 <!--  Hotkeys  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=HotKeys}" />
-                <ItemsControl IsEnabled="{x:Bind ViewModel.HotkeysEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" ItemsSource="{x:Bind ViewModel.HotkeysCollection, Mode=OneWay}">
+                <ItemsControl ItemsSource="{x:Bind ViewModel.HotkeysCollection, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="models:HotkeysDataObject">
 

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml
@@ -1,13 +1,13 @@
-<Page
+﻿<Page
     x:Class="AutoDarkModeApp.Views.HotkeysPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:AutoDarkModeApp.Helpers"
-    xmlns:local="using:AutoDarkModeApp.Views"
-    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:AutoDarkModeApp.Models"
     mc:Ignorable="d">
     <Page.Resources>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
@@ -17,11 +17,15 @@
         <Grid x:Name="ContentArea">
             <StackPanel Style="{StaticResource PageBaseStackPanelStyle}">
 
-                <InfoBar Message="{helpers:ResourceString Name=HotkeyInfoBarMessage}" IsOpen="True" IsClosable="False" Severity="Informational"/>
+                <!--  Info that can only be edited when hotkeys are disabled  -->
+                <InfoBar
+                    IsClosable="False"
+                    IsOpen="True"
+                    Message="{helpers:ResourceString Name=HotkeyInfoBarMessage}"
+                    Severity="Informational" />
 
                 <!--  Settings  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Settings}" />
-
                 <controls:SettingsCard Header="{helpers:ResourceString Name=EnableHotkeys}">
                     <ToggleSwitch x:Name="HotkeysToggleSwitch" IsOn="{x:Bind ViewModel.HotkeysEnabled, Mode=TwoWay}" />
                 </controls:SettingsCard>
@@ -31,6 +35,7 @@
                 <controls:SettingsCard Header="{helpers:ResourceString Name=ShowNotificationPostponeToggled}" IsEnabled="{x:Bind ViewModel.HotkeysEnabled, Mode=OneWay}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.HotkeyTogglePostponeNotificationEnabled, Mode=TwoWay}" />
                 </controls:SettingsCard>
+                <!--  Force save settingscard  -->
                 <controls:SettingsCard Header="{helpers:ResourceString Name=Msg_HotkeyProblem}" IsEnabled="{x:Bind ViewModel.HotkeysEnabled, Mode=OneWay}">
                     <Button
                         x:Name="SaveSettingsButton"
@@ -47,14 +52,12 @@
 
                 <!--  Hotkeys  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=HotKeys}" />
+                <ItemsControl IsEnabled="{x:Bind ViewModel.HotkeysEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}" ItemsSource="{x:Bind ViewModel.HotkeysCollection, Mode=OneWay}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:HotkeysDataObject">
 
-                <ItemsRepeater x:Name="HotkeysItemView">
-                    <ItemsRepeater.ItemTemplate>
-                        <DataTemplate x:DataType="local:HotkeysDataObject">
-                            <controls:SettingsCard
-                                Margin="0,0,0,4"
-                                Header="{x:Bind DisplayName}"
-                                IsEnabled="{Binding IsOn, ElementName=HotkeysToggleSwitch, Converter={StaticResource BoolNegationConverter}}">
+                            <!--  Hotkey editing and displays settingscard  -->
+                            <controls:SettingsCard Margin="0,0,0,4" Header="{x:Bind DisplayName}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <TextBox
                                         MinWidth="160"
@@ -73,9 +76,10 @@
                                     </Button>
                                 </StackPanel>
                             </controls:SettingsCard>
+
                         </DataTemplate>
-                    </ItemsRepeater.ItemTemplate>
-                </ItemsRepeater>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
 
             </StackPanel>
         </Grid>

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml
@@ -14,13 +14,6 @@
         <Grid x:Name="ContentArea">
             <StackPanel Style="{StaticResource PageBaseStackPanelStyle}">
 
-                <!--  Info that can only be edited when hotkeys are disabled  -->
-                <InfoBar
-                    IsClosable="False"
-                    IsOpen="True"
-                    Message="{helpers:ResourceString Name=HotkeyInfoBarMessage}"
-                    Severity="Informational" />
-
                 <!--  Settings  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Settings}" />
                 <controls:SettingsCard Header="{helpers:ResourceString Name=EnableHotkeys}">

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -27,12 +27,12 @@ public sealed partial class HotkeysPage : Page
             return;
         }
 
-        var keyString = ViewModel.GetHotkeyValue(hotkeyData.Tag);
+        var keyValue = ViewModel.GetHotkeyValue(hotkeyData.Tag);
         var dialogContent = new ShortcutDialogContentControl();
 
-        if (keyString is not null)
+        if (keyValue is not null)
         {
-            dialogContent.LoadFromConfig(keyString);
+            dialogContent.LoadFromKeyValue(keyValue);
         }
 
         var shortcutDialog = new ContentDialog()

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -32,7 +32,7 @@ public sealed partial class HotkeysPage : Page
 
         if (keyString is not null)
         {
-            dialogContent.HotkeyCombination = keyString.Split(" + ").Select(key => new SingleHotkeyDataObject { Key = key }).ToList();
+            dialogContent.LoadFromConfig(keyString);
         }
 
         var shortcutDialog = new ContentDialog()

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -1,12 +1,8 @@
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using AutoDarkModeApp.Contracts.Services;
+﻿using AutoDarkModeApp.Contracts.Services;
 using AutoDarkModeApp.Helpers;
+using AutoDarkModeApp.Models;
 using AutoDarkModeApp.UserControls;
 using AutoDarkModeApp.ViewModels;
-using AutoDarkModeLib;
-using AutoDarkModeLib.Configs;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -15,7 +11,6 @@ namespace AutoDarkModeApp.Views;
 public sealed partial class HotkeysPage : Page
 {
     private readonly IErrorService _errorService = App.GetService<IErrorService>();
-    private readonly AdmConfigBuilder _builder = AdmConfigBuilder.Instance();
 
     public HotkeysViewModel ViewModel { get; }
 
@@ -23,65 +18,19 @@ public sealed partial class HotkeysPage : Page
     {
         ViewModel = App.GetService<HotkeysViewModel>();
         InitializeComponent();
-
-        try
-        {
-            _builder.Load();
-        }
-        catch (Exception ex)
-        {
-            _errorService.ShowErrorMessage(ex, this.XamlRoot, "HotkeysPage");
-        }
-
-        LoadSettings();
-    }
-
-    private void LoadSettings()
-    {
-        var hotkeyConfigs = new[]
-        {
-            new { NameKey = "ForceLight", ConfigKey = nameof(Hotkeys.ForceLight) },
-            new { NameKey = "ForceDark", ConfigKey = nameof(Hotkeys.ForceDark) },
-            new { NameKey = "StopForcing", ConfigKey = nameof(Hotkeys.NoForce) },
-            new { NameKey = "ToggleTheme", ConfigKey = nameof(Hotkeys.ToggleTheme) },
-            new { NameKey = "AutomaticThemeSwitch", ConfigKey = nameof(Hotkeys.ToggleAutoThemeSwitch) },
-            new { NameKey = "PauseAutoThemeSwitching", ConfigKey = nameof(Hotkeys.TogglePostpone) },
-        };
-
-        var hotkeysCollection = new ObservableCollection<HotkeysDataObject>(
-            hotkeyConfigs.Select(cfg =>
-            {
-                var propertyInfo = typeof(Hotkeys).GetProperty(cfg.ConfigKey) ?? throw new InvalidOperationException($"Property '{cfg.ConfigKey}' not found on type 'Hotkeys'.");
-                return new HotkeysDataObject
-                {
-                    DisplayName = cfg.NameKey.GetLocalized(),
-                    Keys = (string?)propertyInfo.GetValue(_builder.Config.Hotkeys),
-                    Tag = cfg.NameKey,
-                };
-            })
-        );
-
-        HotkeysItemView.ItemsSource = hotkeysCollection;
     }
 
     private async void EditHotkeysButton_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button button || button.CommandParameter is not HotkeysDataObject hotkeyData)
-            return;
-
-        var keyString = hotkeyData.Tag switch
+        if (sender is not Button button || button.CommandParameter is not HotkeysDataObject hotkeyData || hotkeyData.Tag is null)
         {
-            "ForceLight" => _builder.Config.Hotkeys.ForceLight,
-            "ForceDark" => _builder.Config.Hotkeys.ForceDark,
-            "StopForcing" => _builder.Config.Hotkeys.NoForce,
-            "ToggleTheme" or "AutomaticThemeSwitch" => _builder.Config.Hotkeys.ToggleAutoThemeSwitch,
-            "PauseAutoThemeSwitching" => _builder.Config.Hotkeys.TogglePostpone,
-            _ => null,
-        };
+            return;
+        }
 
+        var keyString = ViewModel.GetHotkeyValue(hotkeyData.Tag);
         var dialogContent = new ShortcutDialogContentControl();
 
-        if (keyString != null)
+        if (keyString is not null)
         {
             dialogContent.HotkeyCombination = keyString.Split(" + ").Select(key => new SingleHotkeyDataObject { Key = key }).ToList();
         }
@@ -109,41 +58,15 @@ public sealed partial class HotkeysPage : Page
             return;
         }
 
-        var collection = (ObservableCollection<HotkeysDataObject>)HotkeysItemView.ItemsSource;
-        var tag = hotkeyData.Tag;
-
-        var propertyMap = new Dictionary<string, (Action<string> Setter, string Tag)>
-        {
-            ["ForceLight"] = (v => _builder.Config.Hotkeys.ForceLight = v, "ForceLight"),
-            ["ForceDark"] = (v => _builder.Config.Hotkeys.ForceDark = v, "ForceDark"),
-            ["StopForcing"] = (v => _builder.Config.Hotkeys.NoForce = v, "StopForcing"),
-            ["ToggleTheme"] = (v => _builder.Config.Hotkeys.ToggleTheme = v, "ToggleTheme"),
-            ["AutomaticThemeSwitch"] = (v => _builder.Config.Hotkeys.ToggleAutoThemeSwitch = v, "AutomaticThemeSwitch"),
-            ["PauseAutoThemeSwitching"] = (v => _builder.Config.Hotkeys.TogglePostpone = v, "PauseAutoThemeSwitching"),
-        };
-
-        if (propertyMap.TryGetValue(tag!, out var config))
-        {
-            config.Setter(dialogContent.CapturedHotkeys!);
-            if (collection.FirstOrDefault(h => h.Tag == config.Tag) is { } itemToUpdate)
-            {
-                itemToUpdate.Keys = dialogContent.CapturedHotkeys;
-            }
-        }
-
-        try
-        {
-            _builder.Save();
-        }
-        catch (Exception ex)
-        {
-            await _errorService.ShowErrorMessage(ex, this.XamlRoot, "HotkeysPage");
-        }
+        ViewModel.UpdateHotkeyValue(hotkeyData.Tag, dialogContent.CapturedHotkeys);
     }
 
     private async void SaveSettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button button) return;
+        if (sender is not Button button)
+        {
+            return;
+        }
 
         var originalContent = button.Content;
         var originalMinWidth = button.MinWidth;
@@ -156,15 +79,8 @@ public sealed partial class HotkeysPage : Page
 
         try
         {
-            var collection = (ObservableCollection<HotkeysDataObject>)HotkeysItemView.ItemsSource;
-            _builder.Config.Hotkeys.ForceLight = collection.FirstOrDefault(h => h.Tag == "ForceLight")?.Keys;
-            _builder.Config.Hotkeys.ForceDark = collection.FirstOrDefault(h => h.Tag == "ForceDark")?.Keys;
-            _builder.Config.Hotkeys.NoForce = collection.FirstOrDefault(h => h.Tag == "StopForcing")?.Keys;
-            _builder.Config.Hotkeys.ToggleTheme = collection.FirstOrDefault(h => h.Tag == "ToggleTheme")?.Keys;
-            _builder.Config.Hotkeys.ToggleAutoThemeSwitch = collection.FirstOrDefault(h => h.Tag == "AutomaticThemeSwitch")?.Keys;
-            _builder.Config.Hotkeys.TogglePostpone = collection.FirstOrDefault(h => h.Tag == "PauseAutoThemeSwitching")?.Keys;
-
-            var saveTask = Task.Run(() => _builder.Save());
+            ViewModel.ForceSaveHotkeysSettings();
+            var saveTask = Task.Run(() => ViewModel.SafeSaveBuilder());
             var delayTask = Task.Delay(1000);
             await Task.WhenAll(saveTask, delayTask);
 
@@ -183,49 +99,5 @@ public sealed partial class HotkeysPage : Page
             button.Content = originalContent is string ? "ForceSaveSettings".GetLocalized() : originalContent;
             button.IsEnabled = true;
         }
-    }
-}
-
-public partial class HotkeysDataObject : INotifyPropertyChanged
-{
-    private string? _displayName { get; set; }
-    private string? _keys { get; set; }
-    private string? _tag { get; set; }
-
-    public string? DisplayName
-    {
-        get => _displayName;
-        set
-        {
-            _displayName = value;
-            OnPropertyChanged();
-        }
-    }
-
-    public string? Keys
-    {
-        get => _keys;
-        set
-        {
-            _keys = value;
-            OnPropertyChanged();
-        }
-    }
-
-    public string? Tag
-    {
-        get => _tag;
-        set
-        {
-            _tag = value;
-            OnPropertyChanged();
-        }
-    }
-
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/AutoDarkModeLib/Helper.cs
+++ b/AutoDarkModeLib/Helper.cs
@@ -264,7 +264,6 @@ public static class HotkeyStringConverter
 
     private static readonly Dictionary<string, string> WinFormsKeyMap = new()
     {
-        { "Control", "Ctrl" },
         { "LWin", "Win" },
         { "RWin", "Win" },
         { "Back", "Backspace" },
@@ -272,6 +271,7 @@ public static class HotkeyStringConverter
         { "Prior", "PgUp" },
         { "Next", "PgDn" },
         { "Capital", "CapsLock" },
+        { "Apps", "Application" },
         { "Oemcomma", "," },
         { "OemPeriod", "." },
         { "OemQuestion", "/" },
@@ -282,7 +282,17 @@ public static class HotkeyStringConverter
         { "OemPipe", "\\" },
         { "OemSemicolon", ";" },
         { "OemQuotes", "'" },
-        { "Oemtilde", "`" }
+        { "Oemtilde", "`" },
+        { "D0", "Number0" },
+        { "D1", "Number1" },
+        { "D2", "Number2" },
+        { "D3", "Number3" },
+        { "D4", "Number4" },
+        { "D5", "Number5" },
+        { "D6", "Number6" },
+        { "D7", "Number7" },
+        { "D8", "Number8" },
+        { "D9", "Number9" }
     };
 
     private static readonly Dictionary<string, VirtualKey> SpecialKeyMap = new()
@@ -318,19 +328,34 @@ public static class HotkeyStringConverter
 
     private static readonly Dictionary<VirtualKey, string> ReverseSpecialKeyMap = SpecialKeyMap.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
-    public static bool IsWinFormsFormat(string? hotkeyString)
+    public static bool IsWinFormsFormat(string hotkeyString)
     {
         if (string.IsNullOrWhiteSpace(hotkeyString))
         {
             return false;
         }
 
-        return (hotkeyString.Contains("Control") ||
-                hotkeyString.Contains("LWin") ||
-                hotkeyString.Contains("RWin") ||
-                hotkeyString.Contains("Return") ||
-                hotkeyString.Contains("Oem")) &&
-               !hotkeyString.Contains(" + ");
+        var parts = hotkeyString.Split('+', StringSplitOptions.TrimEntries);
+
+        foreach (var part in parts)
+        {
+            if (part == "LWin"
+                || part == "RWin"
+                || part == "Return"
+                || part == "Prior"
+                || part == "Next"
+                || part == "Capital"
+                || part == "Back"
+                || part == "Apps"
+                || part.StartsWith("Oem")
+                || (part.Length == 2 && part[0] == 'D' && char.IsDigit(part[1]))
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string NormalizeKeyName(string keyName)
@@ -476,17 +501,12 @@ public static class HotkeyStringConverter
             return (uint)upper;
         }
 
-        if (keyName.Length == 2 && keyName[0] == 'D' && char.IsDigit(keyName[1]))
-        {
-            return (uint)(VirtualKey.Number0 + (keyName[1] - '0'));
-        }
-
         return 0;
     }
 
     public static string GetKeyDisplayName(VirtualKey key)
     {
-        if (ReverseSpecialKeyMap.TryGetValue(key, out string? specialName))
+        if (ReverseSpecialKeyMap.TryGetValue(key, out string specialName))
         {
             return specialName;
         }

--- a/AutoDarkModeSvc/Handlers/HotkeyHandler.cs
+++ b/AutoDarkModeSvc/Handlers/HotkeyHandler.cs
@@ -1,174 +1,190 @@
 ﻿#region copyright
-//  Copyright (C) 2022 Auto Dark Mode
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// Copyright (C) 2025 Auto Dark Mode
+// This program is free software under GNU GPL v3.0
 #endregion
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using AutoDarkModeLib;
 using AutoDarkModeLib.Configs;
 using AutoDarkModeSvc.Core;
 
 namespace AutoDarkModeSvc.Handlers;
 
-static class HotkeyHandler
+internal static class HotkeyHandler
 {
-    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-    private static AdmConfigBuilder builder = AdmConfigBuilder.Instance();
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
     public static Service Service { get; set; }
+
     [DllImport("user32.dll")]
     private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
-    // Unregisters the hot key with Windows.
+
     [DllImport("user32.dll")]
     private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
-    public enum ModifierKeys
-    {
-        Alt = 0x1,
-        Control = 0x2,
-        Shift = 0x4,
-        Win = 0x8
-    }
-    private static List<HotkeyInternal> Registered { get; } = new();
 
+    private static List<HotkeyInternal> Registered { get; } = [];
 
     public static void RegisterAllHotkeys(AdmConfigBuilder builder)
     {
-        Logger.Debug("registering hotkeys");
+        _logger.Debug("registering hotkeys");
         try
         {
             GlobalState state = GlobalState.Instance();
 
-            if (builder.Config.Hotkeys.ForceDark != null) Register(builder.Config.Hotkeys.ForceDark, () =>
+            if (builder.Config.Hotkeys.ForceDark != null)
             {
-                Logger.Info("hotkey signal received: forcing dark theme");
-                state.ForcedTheme = Theme.Dark;
-                ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Dark);
-                ThemeManager.UpdateTheme(new(SwitchSource.Manual, Theme.Dark));
-            });
-
-            if (builder.Config.Hotkeys.ForceLight != null) Register(builder.Config.Hotkeys.ForceLight, () =>
-            {
-                Logger.Info("hotkey signal received: forcing light theme");
-                state.ForcedTheme = Theme.Light;
-                ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Light);
-                ThemeManager.UpdateTheme(new(SwitchSource.Manual, Theme.Light));
-            });
-
-            if (builder.Config.Hotkeys.NoForce != null) Register(builder.Config.Hotkeys.NoForce, () =>
-            {
-                Logger.Info("hotkey signal received: stop forcing specific theme");
-                state.ForcedTheme = Theme.Unknown;
-                ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Light);
-                ThemeManager.RequestSwitch(new(SwitchSource.Manual));
-            });
-
-            if (builder.Config.Hotkeys.ToggleTheme != null) Register(builder.Config.Hotkeys.ToggleTheme, () =>
-            {
-                Logger.Info("hotkey signal received: toggle theme");
-                ThemeManager.SwitchThemeAutoPauseAndNotify();
-            });
-
-            if (builder.Config.Hotkeys.ToggleAutoThemeSwitch != null) Register(builder.Config.Hotkeys.ToggleAutoThemeSwitch, () =>
-            {
-                Logger.Info("hotkey signal received: toggle automatic theme switch");
-                AdmConfig old = builder.Config;
-                state.SkipConfigFileReload = true;
-                builder.Config.AutoThemeSwitchingEnabled = !builder.Config.AutoThemeSwitchingEnabled;
-                builder.Save();
-                ToastHandler.InvokeAutoSwitchToggleToast();
-            });
-
-            if (builder.Config.Hotkeys.TogglePostpone != null) Register(builder.Config.Hotkeys.TogglePostpone, () =>
-            {
-                if (builder.Config.AutoThemeSwitchingEnabled)
-                {
-                    if (state.PostponeManager.IsSkipNextSwitch)
+                Register(
+                    builder.Config.Hotkeys.ForceDark,
+                    () =>
                     {
-                        state.PostponeManager.RemoveSkipNextSwitch();
-                        ToastHandler.InvokePauseAutoSwitchToast();
-                        Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(o => ThemeManager.RequestSwitch(new(SwitchSource.Manual)));
+                        _logger.Info("hotkey signal received: forcing dark theme");
+                        state.ForcedTheme = Theme.Dark;
+                        ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Dark);
+                        ThemeManager.UpdateTheme(new(SwitchSource.Manual, Theme.Dark));
                     }
-                    else
+                );
+            }
+
+            if (builder.Config.Hotkeys.ForceLight != null)
+            {
+                Register(
+                    builder.Config.Hotkeys.ForceLight,
+                    () =>
                     {
-                        state.PostponeManager.AddSkipNextSwitch();
-                        ToastHandler.InvokePauseAutoSwitchToast();
+                        _logger.Info("hotkey signal received: forcing light theme");
+                        state.ForcedTheme = Theme.Light;
+                        ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Light);
+                        ThemeManager.UpdateTheme(new(SwitchSource.Manual, Theme.Light));
                     }
-                }
-            });
+                );
+            }
+
+            if (builder.Config.Hotkeys.NoForce != null)
+            {
+                Register(
+                    builder.Config.Hotkeys.NoForce,
+                    () =>
+                    {
+                        _logger.Info("hotkey signal received: stop forcing specific theme");
+                        state.ForcedTheme = Theme.Unknown;
+                        ThemeHandler.EnforceNoMonitorUpdates(builder, state, Theme.Light);
+                        ThemeManager.RequestSwitch(new(SwitchSource.Manual));
+                    }
+                );
+            }
+
+            if (builder.Config.Hotkeys.ToggleTheme != null)
+            {
+                Register(
+                    builder.Config.Hotkeys.ToggleTheme,
+                    () =>
+                    {
+                        _logger.Info("hotkey signal received: toggle theme");
+                        ThemeManager.SwitchThemeAutoPauseAndNotify();
+                    }
+                );
+            }
+
+            if (builder.Config.Hotkeys.ToggleAutoThemeSwitch != null)
+            {
+                Register(
+                    builder.Config.Hotkeys.ToggleAutoThemeSwitch,
+                    () =>
+                    {
+                        _logger.Info("hotkey signal received: toggle automatic theme switch");
+                        AdmConfig old = builder.Config;
+                        state.SkipConfigFileReload = true;
+                        builder.Config.AutoThemeSwitchingEnabled = !builder.Config.AutoThemeSwitchingEnabled;
+                        builder.Save();
+                        ToastHandler.InvokeAutoSwitchToggleToast();
+                    }
+                );
+            }
+
+            if (builder.Config.Hotkeys.TogglePostpone != null)
+            {
+                Register(
+                    builder.Config.Hotkeys.TogglePostpone,
+                    () =>
+                    {
+                        if (builder.Config.AutoThemeSwitchingEnabled)
+                        {
+                            if (state.PostponeManager.IsSkipNextSwitch)
+                            {
+                                state.PostponeManager.RemoveSkipNextSwitch();
+                                ToastHandler.InvokePauseAutoSwitchToast();
+                                Task.Delay(TimeSpan.FromSeconds(2)).ContinueWith(o => ThemeManager.RequestSwitch(new(SwitchSource.Manual)));
+                            }
+                            else
+                            {
+                                state.PostponeManager.AddSkipNextSwitch();
+                                ToastHandler.InvokePauseAutoSwitchToast();
+                            }
+                        }
+                    }
+                );
+            }
         }
         catch (Exception ex)
         {
-            Logger.Error(ex, "could not register hotkeys:");
+            _logger.Error(ex, "could not register hotkeys:");
         }
-
     }
 
     public static void UnregisterAllHotkeys()
     {
-        Logger.Debug("removing hotkeys");
+        _logger.Debug("removing hotkeys");
         Registered.ForEach(hk => Unregister(hk.Id));
         Registered.Clear();
     }
 
-    public static HotkeyInternal GetRegistered(List<Keys> modifiersPressed, Keys key)
+    public static HotkeyInternal GetRegistered(uint modifiers, uint keyCode)
     {
-        return Registered.Find(hk => Enumerable.SequenceEqual(hk.Modifiers.OrderBy(e => e), modifiersPressed.OrderBy(e => e)) && hk.Key == key);
+        return Registered.Find(hk => hk.Modifiers == modifiers && hk.KeyCode == keyCode);
     }
 
     private static void Register(string hotkeyString, Action action)
     {
         if (Service == null)
         {
-            Logger.Error("service not instantiated while trying to register hotkey");
+            _logger.Error("service not instantiated while trying to register hotkey");
+            return;
         }
-        List<Keys> keys = GetKeyList(hotkeyString);
-        HotkeyInternal mappedHotkey = new() { StringCode = hotkeyString, Action = action };
 
-        keys.ForEach((k) =>
+        try
         {
-            if (IsModifier(k)) mappedHotkey.Modifiers.Add(k);
-            else mappedHotkey.Key = k;
-        });
+            var parts = hotkeyString.Split(',');
+            if (parts.Length != 2 || !uint.TryParse(parts[0], out uint modifiers) || !uint.TryParse(parts[1], out uint keyCode))
+            {
+                _logger.Error($"Invalid hotkey format: {hotkeyString}");
+                return;
+            }
 
-        if (mappedHotkey.Modifiers.Count == 0)
-        {
-            throw new InvalidOperationException("hotkey must contain at least one of these modifiers: Shift, Alt, Ctrl, LWin, RWin");
+            HotkeyInternal mappedHotkey = new()
+            {
+                StringCode = hotkeyString,
+                Modifiers = modifiers,
+                KeyCode = keyCode,
+                Action = action,
+            };
+
+            Registered.Add(mappedHotkey);
+
+            Service.Invoke(new Action(() => RegisterHotKey(Service.Handle, 0, modifiers, keyCode)));
         }
-        Registered.Add(mappedHotkey);
-        uint modifiersJoined = mappedHotkey.Modifiers.Select(m =>
+        catch (Exception ex)
         {
-            if (m == Keys.Shift) return ModifierKeys.Shift;
-            else if (m == Keys.Control) return ModifierKeys.Control;
-            else if (m == Keys.Alt) return ModifierKeys.Alt;
-            return ModifierKeys.Win;
-        }).Select(m => (uint)m).Aggregate((accu, cur) => accu | cur);
-
-        //Service.Invoke(new Action(() => RegisterHotKey(Service.Handle, 0, (uint)ModifierKeys.Win | (uint)ModifierKeys.Control, (int)Keys.A)));
-        Service.Invoke(new Action(() => RegisterHotKey(Service.Handle, 0, modifiersJoined, (uint)mappedHotkey.Key)));
-
+            _logger.Error(ex, $"Failed to register hotkey: {hotkeyString}");
+        }
     }
 
     private static void Unregister(int id)
     {
         if (Service == null)
         {
-            Logger.Error("service not instantiated while trying to unregister hotkey");
+            _logger.Error("service not instantiated while trying to unregister hotkey");
         }
         HotkeyInternal mappedHotkey = Registered.Find(hk => hk.Id == id);
         if (mappedHotkey != null)
@@ -176,41 +192,13 @@ static class HotkeyHandler
             Service.Invoke(new Action(() => UnregisterHotKey(Service.Handle, mappedHotkey.Id)));
         }
     }
-
-    private static List<Keys> GetKeyList(string hotkeyString)
-    {
-        string[] splitKeys = hotkeyString.Split("+");
-        KeysConverter converter = new();
-        List<Keys> keys = new();
-        CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en");
-        foreach (string keyString in splitKeys)
-        {
-            Keys key = (Keys)converter.ConvertFromInvariantString(keyString);
-            keys.Add(key);
-        }
-        CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(builder.Config.Tunable.UICulture);
-        return keys;
-    }
-
-    private static bool IsModifier(Keys key)
-    {
-        if (key == Keys.Shift ||
-            key == Keys.Control ||
-            key == Keys.Alt ||
-            key == Keys.LWin ||
-            key == Keys.RWin)
-        {
-            return true;
-        }
-        return false;
-    }
 }
 
 public class HotkeyInternal
 {
     public int Id { get; set; }
     public string StringCode { get; set; }
-    public List<Keys> Modifiers { get; set; } = new();
-    public Keys Key { get; set; }
+    public uint Modifiers { get; set; }
+    public uint KeyCode { get; set; }
     public Action Action { get; set; }
 }

--- a/AutoDarkModeSvc/Service.cs
+++ b/AutoDarkModeSvc/Service.cs
@@ -472,24 +472,11 @@ class Service : Form
     {
         if (m.Msg == WM_HOTKEY && m.WParam == (IntPtr)0)
         {
-            int modifiers = (int)m.LParam & 0xFFFF;
-            Keys key = (Keys)(((int)m.LParam >> 16) & 0xFFFF);
-            List<Keys> modifiersPressed = new();
-            if ((modifiers & (int)HotkeyHandler.ModifierKeys.Alt) != 0) modifiersPressed.Add(Keys.Alt);
-            if ((modifiers & (int)HotkeyHandler.ModifierKeys.Shift) != 0) modifiersPressed.Add(Keys.Shift);
-            if ((modifiers & (int)HotkeyHandler.ModifierKeys.Control) != 0) modifiersPressed.Add(Keys.Control);
-            if ((modifiers & (int)HotkeyHandler.ModifierKeys.Win) != 0) modifiersPressed.Add(Keys.LWin);
+            uint modifiers = (uint)((int)m.LParam & 0xFFFF);
+            uint keyCode = (uint)(((int)m.LParam >> 16) & 0xFFFF);
 
-            var match = HotkeyHandler.GetRegistered(modifiersPressed, key);
-            if (match == null)
-            {
-                if (modifiersPressed.Contains(Keys.LWin))
-                {
-                    modifiersPressed.Remove(Keys.LWin);
-                    modifiersPressed.Add(Keys.RWin);
-                }
-                match = HotkeyHandler.GetRegistered(modifiersPressed, key);
-            }
+            var match = HotkeyHandler.GetRegistered(modifiers, keyCode);
+
             if (match != null)
             {
                 try


### PR DESCRIPTION
### Description

This is a huge PR, but it doesn't actually involve any function update. The only function change is that we can edit hotkeys when the hotkey function is disabled. See it in https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/issues/702#issuecomment-3418007928. Let me briefly explain this PR:

- Change the front-end and back-end to use [`Virtual-Key`](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) at the same time (this is not the exclusive benefit of Windows App SDK, this comes from win32). Because the [`RegisterHotKey`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey) already uses `Virtual-Key`, it is not necessary to convert `Winform's Keys` into VK.
- The configuration file needs to be changed. In the past, each key was connected by `+`, but now we change it to **Decorative key code** and **primary key code**, which are connected by `,`.

Before:

```yaml
Hotkeys:
  Enabled: true
  ForceLight: Ctrl + D1
  ForceDark: 
```

After:

```yaml
Hotkeys:
  Enabled: true
  ForceLight: 2,49
  ForceDark: 
```

- So the first is the change of the back end **HotkeyHandler**. There is no need to convert `Keys` to VK in the `Register` function. We only need to split the configuration obtained by `builder`, and we will get the original `Modifiers` and `keys`. Just call the `RegisterHotKey` directly.

Before:

```c#
public class HotkeyInternal
{
    public int Id { get; set; }
    public string StringCode { get; set; }
    public List<Keys> Modifiers { get; set; } = new();
    public Keys Key { get; set; }
    public Action Action { get; set; }
}
```

After:

```c#
public class HotkeyInternal
{
    public int Id { get; set; }
    public string StringCode { get; set; }
    public uint Modifiers { get; set; }
    public uint KeyCode { get; set; }
    public Action Action { get; set; }
}
```

- Then there is the change about the **Service**, and this part will become extremely simple! The `WM_HOTKEY` message originally uses `Virtual-Key` Code: the lower 16 bits of `lParam` are decorative key marks, and the upper 16 bits are virtual keycode.
- Then the front end part was modified by MVVM, and the `HotkeysDataObject` was put into **Models**. Then the original way of reading keys is modified. Just convert the read `Virtual-Key`. (It's just one more step ( •̀ ω •́ )✧)

Code:

```c#
    private static string GetKeyDisplayName(VirtualKey key)
    {
        return key switch
        {
            VirtualKey.Enter => "Enter",
            VirtualKey.Escape => "Esc",
            VirtualKey.Space => "Space",
            VirtualKey.Back => "Backspace",
            VirtualKey.Delete => "Del",
            VirtualKey.PageUp => "PgUp",
            VirtualKey.PageDown => "PgDn",
            VirtualKey.CapitalLock => "CapsLock",
            (VirtualKey)188 => ",",
            (VirtualKey)190 => ".",
            (VirtualKey)191 => "/",
            (VirtualKey)187 => "=",
            (VirtualKey)189 => "-",
            (VirtualKey)219 => "[",
            (VirtualKey)221 => "]",
            (VirtualKey)220 => "\\",
            (VirtualKey)186 => ";",
            (VirtualKey)222 => "'",
            (VirtualKey)192 => "`",
            _ => key.ToString(),
        };
    }
```

### Screenshots

![PixPin_2025-10-18_23-31-32](https://github.com/user-attachments/assets/36aa2a25-e535-4fd4-83cf-d9b6d9ddbe94)


That's all about the explanation. I hope this is a good step to start updating the 11.X version.
At the same time, @Spiritreader @Armin2208 need you to check more. I'm worried that some minor mistakes will ruin the back end. Thank you very much!