### PR TITLE
fix(i18n): remove stray colon from Japanese translation of SystemAreas string

### DIFF
--- a/AutoDarkModeApp/Strings/ja/Resources.resw
+++ b/AutoDarkModeApp/Strings/ja/Resources.resw
@@ -745,7 +745,7 @@ Auto Dark Mode のリポジトリに issue (問題) を投稿しますか？
     <value>システム:</value>
   </data>
   <data name="SystemAreas" xml:space="preserve">
-    <value>アプリケーション:</value>
+    <value>アプリケーション</value>
   </data>
   <data name="Task" xml:space="preserve">
     <value>タスク</value>


### PR DESCRIPTION
## Change Description
Remove an accidental trailing ':' from AutoDarkModeApp/Strings/ja/Resources.resw (line ~748). This fixes the menu label showing "アプリケーション:" — no functional changes, only a text/UI correction.

NOTE: The GitHub text editor made a change at L1029. I didn't intend for it to happen - I'm sorry.

(will add a screenshot of the current state)