### PR TITLE
Code quality: Using IconSource of TitleBar

### DIFF
--- a/AutoDarkModeApp/AutoDarkModeApp.csproj
+++ b/AutoDarkModeApp/AutoDarkModeApp.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.TokenizingTextBox" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250907003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />

--- a/AutoDarkModeApp/MainWindow.xaml
+++ b/AutoDarkModeApp/MainWindow.xaml
@@ -19,19 +19,16 @@
         </Grid.RowDefinitions>
         <TitleBar
             x:Name="TitleBar"
-            Title="        Auto Dark Mode"
+            Title="Auto Dark Mode"
             BackRequested="NavViewTitleBar_BackRequested"
             IsBackButtonEnabled="{x:Bind NavigationFrame.CanGoBack, Mode=OneWay}"
             IsBackButtonVisible="True"
             IsPaneToggleButtonVisible="True"
             PaneToggleRequested="NavViewTitleBar_PaneToggleRequested">
-            <!--  This is a workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/10374, once fixed we should just be using IconSource  -->
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="/Assets/AutoDarkModeIcon.ico" />
+            </TitleBar.IconSource>
         </TitleBar>
-        <ImageIcon
-            Height="16"
-            Margin="100,0,0,0"
-            HorizontalAlignment="Left"
-            Source="/Assets/AutoDarkModeIcon.ico" />
 
         <NavigationView
             x:Name="NavigationViewControl"


### PR DESCRIPTION
### Descrition

`IconSource` property of TitleBar can't be used normally because of a bug in WinUI. This Bug has been fixed after the update, so we resumed normal use.