### PR TITLE
Code quality: Add services for window closing

### DIFF
--- a/AutoDarkModeApp/App.xaml.cs
+++ b/AutoDarkModeApp/App.xaml.cs
@@ -25,6 +25,8 @@ public partial class App : Application
     // https://docs.microsoft.com/dotnet/core/extensions/logging
     public IHost Host { get; }
 
+    // TODO: Avoid static GetService<T>(); prefer constructor injection.
+
     public static T GetService<T>()
         where T : class
     {
@@ -36,32 +38,21 @@ public partial class App : Application
         return service;
     }
 
-    public static void CheckAppMutex()
-    {
-        if (!Mutex.WaitOne(TimeSpan.FromMilliseconds(50), false) && !Debugger.IsAttached)
-        {
-            List<Process> processes = [.. Process.GetProcessesByName("AutoDarkModeApp")];
-            if (processes.Count > 0)
-            {
-                Helpers.WindowHelper.BringProcessToFront(processes[0]);
-                App.Current.Exit();
-            }
-        }
-    }
-
-    public static Window? MainWindow { get; set; }
+    // Expose the DI-created MainWindow for legacy call sites.
+    // This preserves compatibility with existing App.MainWindow usages.
+    // Consider refactoring callers to use dependency injection directly.
+    public static MainWindow MainWindow =>
+        (Current as App)!.Host.Services.GetRequiredService<MainWindow>();
 
     public App()
     {
         CheckAppMutex();
-
         InitializeComponent();
 
-        Host = Microsoft
-            .Extensions.Hosting.Host.CreateDefaultBuilder()
+        Host = Microsoft.Extensions.Hosting.Host
+            .CreateDefaultBuilder()
             .UseContentRoot(AppContext.BaseDirectory)
-            .ConfigureServices(
-                (context, services) =>
+            .ConfigureServices((context, services) =>
                 {
                     // Services
                     services.AddSingleton<ILocalSettingsService, LocalSettingsService>();
@@ -115,6 +106,20 @@ public partial class App : Application
         UnhandledException += App_UnhandledException;
     }
 
+    public static void CheckAppMutex()
+    {
+        if (!Mutex.WaitOne(TimeSpan.FromMilliseconds(50), false) && !Debugger.IsAttached)
+        {
+            var processes = Process.GetProcessesByName("AutoDarkModeApp").Where(p => p.Id != Environment.ProcessId).ToList();
+            if (processes.Count > 0)
+            {
+                Helpers.WindowHelper.BringProcessToFront(processes[0]);
+                App.Current.Exit();
+            }
+        }
+    }
+
+
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
         // TODO: Log and handle exceptions as appropriate.
@@ -131,21 +136,23 @@ public partial class App : Application
         {
             new PipeClient().SendMessageAndGetReply(arguments[1]);
             App.Current.Exit();
+            return;
         }
 
-        // Set App and Svc language
+        // Set App and SVC language
         Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = await LanguageHelper.GetDefaultLanguageAsync();
         await Task.Run(() =>
         {
             var builder = AdmConfigBuilder.Instance();
             builder.Load();
-            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode;
+            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode; // For SVC and other services that need to know the UI culture
             builder.Save();
         });
 
-        MainWindow = App.GetService<MainWindow>();
-        MainWindow.Closed += async (s, e) => await App.GetService<ICloseService>().CloseAsync();
+        var mainWindow = Host.Services.GetRequiredService<MainWindow>();
+        mainWindow.Closed += async (s, e) => await Host.Services.GetRequiredService<ICloseService>().CloseAsync();
 
-        await App.GetService<IActivationService>().ActivateAsync(args);
+        await Host.Services.GetRequiredService<IActivationService>().ActivateAsync(args);
+        mainWindow.Activate();
     }
 }

--- a/AutoDarkModeApp/App.xaml.cs
+++ b/AutoDarkModeApp/App.xaml.cs
@@ -67,11 +67,15 @@ public partial class App : Application
             services.AddSingleton<IFileService, FileService>();
 
             services.AddSingleton<IActivationService, ActivationService>();
+            services.AddSingleton<ICloseService, CloseService>();
             services.AddSingleton<IPageService, PageService>();
             services.AddSingleton<INavigationService, NavigationService>();
 
             services.AddSingleton<IErrorService, ErrorService>();
             services.AddSingleton<IGeolocatorService, GeolocatorService>();
+
+            // Window
+            services.AddSingleton<MainWindow>();
 
             // Views and ViewModels
             services.AddTransient<ThemePickerViewModel>();
@@ -142,7 +146,8 @@ public partial class App : Application
             //await App.GetService<IErrorService>().ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "Startup", "Failed to force-set Svc language");
         }
 
-        MainWindow = new MainWindow();
+        MainWindow = App.GetService<MainWindow>();
+        MainWindow.Closed += async (s, e) => await App.GetService<ICloseService>().CloseAsync();
 
         await App.GetService<IActivationService>().ActivateAsync(args);
     }

--- a/AutoDarkModeApp/App.xaml.cs
+++ b/AutoDarkModeApp/App.xaml.cs
@@ -57,58 +57,60 @@ public partial class App : Application
 
         InitializeComponent();
 
-        Host = Microsoft.Extensions.Hosting.Host.
-        CreateDefaultBuilder().
-        UseContentRoot(AppContext.BaseDirectory).
-        ConfigureServices((context, services) =>
-        {
-            // Services
-            services.AddSingleton<ILocalSettingsService, LocalSettingsService>();
-            services.AddSingleton<IFileService, FileService>();
+        Host = Microsoft
+            .Extensions.Hosting.Host.CreateDefaultBuilder()
+            .UseContentRoot(AppContext.BaseDirectory)
+            .ConfigureServices(
+                (context, services) =>
+                {
+                    // Services
+                    services.AddSingleton<ILocalSettingsService, LocalSettingsService>();
+                    services.AddSingleton<IFileService, FileService>();
 
-            services.AddSingleton<IActivationService, ActivationService>();
-            services.AddSingleton<ICloseService, CloseService>();
-            services.AddSingleton<IPageService, PageService>();
-            services.AddSingleton<INavigationService, NavigationService>();
+                    services.AddSingleton<IActivationService, ActivationService>();
+                    services.AddSingleton<ICloseService, CloseService>();
+                    services.AddSingleton<IPageService, PageService>();
+                    services.AddSingleton<INavigationService, NavigationService>();
 
-            services.AddSingleton<IErrorService, ErrorService>();
-            services.AddSingleton<IGeolocatorService, GeolocatorService>();
+                    services.AddSingleton<IErrorService, ErrorService>();
+                    services.AddSingleton<IGeolocatorService, GeolocatorService>();
 
-            // Window
-            services.AddSingleton<MainWindow>();
+                    // Window
+                    services.AddSingleton<MainWindow>();
 
-            // Views and ViewModels
-            services.AddTransient<ThemePickerViewModel>();
-            services.AddTransient<ThemePickerPage>();
-            services.AddTransient<CursorsViewModel>();
-            services.AddTransient<CursorsPage>();
-            services.AddTransient<ColorizationViewModel>();
-            services.AddTransient<ColorizationPage>();
-            services.AddTransient<SettingsViewModel>();
-            services.AddTransient<SettingsPage>();
-            services.AddTransient<AboutViewModel>();
-            services.AddTransient<AboutPage>();
-            services.AddTransient<DonationViewModel>();
-            services.AddTransient<DonationPage>();
-            services.AddTransient<ScriptsViewModel>();
-            services.AddTransient<ScriptsPage>();
-            services.AddTransient<PersonalizationViewModel>();
-            services.AddTransient<PersonalizationPage>();
-            services.AddTransient<SystemAreasViewModel>();
-            services.AddTransient<SystemAreasPage>();
-            services.AddTransient<ConditionsViewModel>();
-            services.AddTransient<ConditionsPage>();
-            services.AddTransient<HotkeysViewModel>();
-            services.AddTransient<HotkeysPage>();
-            services.AddTransient<WallpaperPickerViewModel>();
-            services.AddTransient<WallpaperPickerPage>();
-            services.AddTransient<TimeViewModel>();
-            services.AddTransient<TimePage>();
+                    // Views and ViewModels
+                    services.AddTransient<ThemePickerViewModel>();
+                    services.AddTransient<ThemePickerPage>();
+                    services.AddTransient<CursorsViewModel>();
+                    services.AddTransient<CursorsPage>();
+                    services.AddTransient<ColorizationViewModel>();
+                    services.AddTransient<ColorizationPage>();
+                    services.AddTransient<SettingsViewModel>();
+                    services.AddTransient<SettingsPage>();
+                    services.AddTransient<AboutViewModel>();
+                    services.AddTransient<AboutPage>();
+                    services.AddTransient<DonationViewModel>();
+                    services.AddTransient<DonationPage>();
+                    services.AddTransient<ScriptsViewModel>();
+                    services.AddTransient<ScriptsPage>();
+                    services.AddTransient<PersonalizationViewModel>();
+                    services.AddTransient<PersonalizationPage>();
+                    services.AddTransient<SystemAreasViewModel>();
+                    services.AddTransient<SystemAreasPage>();
+                    services.AddTransient<ConditionsViewModel>();
+                    services.AddTransient<ConditionsPage>();
+                    services.AddTransient<HotkeysViewModel>();
+                    services.AddTransient<HotkeysPage>();
+                    services.AddTransient<WallpaperPickerViewModel>();
+                    services.AddTransient<WallpaperPickerPage>();
+                    services.AddTransient<TimeViewModel>();
+                    services.AddTransient<TimePage>();
 
-            // Configuration
-            services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));
-        }).
-        Build();
+                    // Configuration
+                    services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));
+                }
+            )
+            .Build();
 
         UnhandledException += App_UnhandledException;
     }
@@ -133,18 +135,13 @@ public partial class App : Application
 
         // Set App and Svc language
         Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = await LanguageHelper.GetDefaultLanguageAsync();
-        var builder = AdmConfigBuilder.Instance();
-        builder.Load();
-        try
+        await Task.Run(() =>
         {
-            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode; // save before activation SVC (think of first-launch scenario)
+            var builder = AdmConfigBuilder.Instance();
+            builder.Load();
+            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode;
             builder.Save();
-        }
-        catch (Exception)
-        {
-            // We can't show a dialog here 
-            //await App.GetService<IErrorService>().ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "Startup", "Failed to force-set Svc language");
-        }
+        });
 
         MainWindow = App.GetService<MainWindow>();
         MainWindow.Closed += async (s, e) => await App.GetService<ICloseService>().CloseAsync();

--- a/AutoDarkModeApp/App.xaml.cs
+++ b/AutoDarkModeApp/App.xaml.cs
@@ -44,12 +44,12 @@ public partial class App : Application
             if (processes.Count > 0)
             {
                 Helpers.WindowHelper.BringProcessToFront(processes[0]);
-                Environment.Exit(-1);
+                App.Current.Exit();
             }
         }
     }
 
-    public static Window MainWindow { get; set; } = Window.Current;
+    public static Window? MainWindow { get; set; }
 
     public App()
     {
@@ -130,7 +130,7 @@ public partial class App : Application
         if (arguments.Length > 1)
         {
             new PipeClient().SendMessageAndGetReply(arguments[1]);
-            Environment.Exit(-1);
+            App.Current.Exit();
         }
 
         // Set App and Svc language

--- a/AutoDarkModeApp/App.xaml.cs
+++ b/AutoDarkModeApp/App.xaml.cs
@@ -25,24 +25,29 @@ public partial class App : Application
     // https://docs.microsoft.com/dotnet/core/extensions/logging
     public IHost Host { get; }
 
-    // TODO: Avoid static GetService<T>(); prefer constructor injection.
-
+    /// <summary>
+    /// Retrieves a registered service of the specified type from the application's dependency injection container.
+    /// </summary>
+    /// <remarks>Use this method to access services configured in the application's dependency injection
+    /// container. Ensure that the service type is registered in the ConfigureServices method of App.xaml.cs before
+    /// calling this method.</remarks>
+    /// <typeparam name="T">The type of service to retrieve. Must be a reference type and registered in the application's service
+    /// collection.</typeparam>
+    /// <returns>An instance of the requested service type <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the requested service type <typeparamref name="T"/> is not registered in the application's service
+    /// collection.</exception>
     public static T GetService<T>()
         where T : class
     {
         if ((Current as App)!.Host.Services.GetService(typeof(T)) is not T service)
         {
-            throw new ArgumentException($"{typeof(T)} needs to be registered in ConfigureServices within App.xaml.cs.");
+            throw new InvalidOperationException($"{typeof(T)} needs to be registered in ConfigureServices within App.xaml.cs.");
         }
 
         return service;
     }
 
-    // Expose the DI-created MainWindow for legacy call sites.
-    // This preserves compatibility with existing App.MainWindow usages.
-    // Consider refactoring callers to use dependency injection directly.
-    public static MainWindow MainWindow =>
-        (Current as App)!.Host.Services.GetRequiredService<MainWindow>();
+    public static MainWindow MainWindow { get; private set; } = null!;
 
     public App()
     {
@@ -67,6 +72,7 @@ public partial class App : Application
                     services.AddSingleton<IGeolocatorService, GeolocatorService>();
 
                     // Window
+                    // NOTE: The MainWindow is registered as a singleton because we only need one instance.
                     services.AddSingleton<MainWindow>();
 
                     // Views and ViewModels
@@ -119,7 +125,6 @@ public partial class App : Application
         }
     }
 
-
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
         // TODO: Log and handle exceptions as appropriate.
@@ -139,20 +144,22 @@ public partial class App : Application
             return;
         }
 
-        // Set App and SVC language
+        // Set App and Svc language
         Microsoft.Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = await LanguageHelper.GetDefaultLanguageAsync();
         await Task.Run(() =>
         {
             var builder = AdmConfigBuilder.Instance();
             builder.Load();
-            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode; // For SVC and other services that need to know the UI culture
+            builder.Config.Tunable.UICulture = LanguageHelper.SelectedLanguageCode; // For Svc and other services that need to know the UI culture
             builder.Save();
         });
 
-        var mainWindow = Host.Services.GetRequiredService<MainWindow>();
-        mainWindow.Closed += async (s, e) => await Host.Services.GetRequiredService<ICloseService>().CloseAsync();
+        // NOTE: Here we use the DI container to get the MainWindow and set it as a static property, which not only conforms to the standard, but also facilitates other places to access the MainWindow.
+        MainWindow = GetService<MainWindow>();
+        MainWindow.Closed += async (s, e) => await GetService<ICloseService>().CloseAsync();
 
-        await Host.Services.GetRequiredService<IActivationService>().ActivateAsync(args);
-        mainWindow.Activate();
+        await GetService<IActivationService>().ActivateAsync(args);
+
+        // NOTE: The MainWindow must be activated (i.e. made visible) in the ActivationService, not here in App.xaml.cs, because there are navigation events and adjustment of window position and size.
     }
 }

--- a/AutoDarkModeApp/Contracts/Services/ICloseService.cs
+++ b/AutoDarkModeApp/Contracts/Services/ICloseService.cs
@@ -1,0 +1,6 @@
+﻿namespace AutoDarkModeApp.Contracts.Services;
+
+public interface ICloseService
+{
+    Task CloseAsync();
+}

--- a/AutoDarkModeApp/Helpers/LanguageHelper.cs
+++ b/AutoDarkModeApp/Helpers/LanguageHelper.cs
@@ -9,7 +9,6 @@ public static class LanguageHelper
 {
     public static string SelectedLanguageCode { get; set; } = "en-US"; // equal to <DefaultLanguage>
 
-    private static readonly ILocalSettingsService _localSettingsService = App.GetService<ILocalSettingsService>()!;
     public static readonly string[] SupportedCultures =
     [
         // Left-to-Right (LTR) languages
@@ -23,7 +22,8 @@ public static class LanguageHelper
 
     public static async Task<string> GetDefaultLanguageAsync()
     {
-        var language = await _localSettingsService.ReadSettingAsync<string>("SelectedLanguageCode");
+        var localSettingsService = App.GetService<ILocalSettingsService>();
+        var language = await localSettingsService.ReadSettingAsync<string>("SelectedLanguageCode");
         if (!string.IsNullOrEmpty(language) && SupportedCultures.Contains(language))
         {
             SelectedLanguageCode = language;
@@ -56,7 +56,7 @@ public static class LanguageHelper
                 }
                 // else keep the default "en-US"
             }
-            await _localSettingsService.SaveSettingAsync("SelectedLanguageCode", SelectedLanguageCode);
+            await localSettingsService.SaveSettingAsync("SelectedLanguageCode", SelectedLanguageCode);
         }
         return SelectedLanguageCode;
     }

--- a/AutoDarkModeApp/MainWindow.xaml.cs
+++ b/AutoDarkModeApp/MainWindow.xaml.cs
@@ -12,6 +12,9 @@ public sealed partial class MainWindow : Window
 {
     private readonly INavigationService _navigationService;
 
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(IntPtr hWnd);
+
     public MainWindow(INavigationService navigationService)
     {
         _navigationService = navigationService;
@@ -30,18 +33,14 @@ public sealed partial class MainWindow : Window
 
         Title = Debugger.IsAttached ? "Auto Dark Mode Debug" : "Auto Dark Mode";
 
-        // TODO: No one knows what the correct way to use it is. Waiting for official examples.
-        [DllImport("user32.dll")]
-        static extern uint GetDpiForWindow([In] IntPtr hwnd);
-        IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-        var dpiForWindow = GetDpiForWindow(hWnd);
-        double scaleFactor = dpiForWindow / 96.0;
+        IntPtr hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        uint dpi = GetDpiForWindow(hwnd);
+        double scaleFactor = dpi / 96.0;
+
         if (AppWindow.Presenter is OverlappedPresenter presenter)
         {
-            presenter.PreferredMinimumWidth = (int)(870 * scaleFactor);
+            presenter.PreferredMinimumWidth = (int)(860 * scaleFactor);
             presenter.PreferredMinimumHeight = (int)(600 * scaleFactor);
-            presenter.PreferredMaximumHeight = 10000;
-            presenter.PreferredMaximumWidth = 10000;
         }
 
         _navigationService.Frame = NavigationFrame;
@@ -67,4 +66,5 @@ public sealed partial class MainWindow : Window
         var backgroundHoverColor = TitleBar.ActualTheme == ElementTheme.Dark ? Color.FromArgb(20, 255, 255, 255) : Color.FromArgb(40, 0, 0, 0);
         AppWindow.TitleBar.ButtonHoverBackgroundColor = backgroundHoverColor;
     }
+
 }

--- a/AutoDarkModeApp/MainWindow.xaml.cs
+++ b/AutoDarkModeApp/MainWindow.xaml.cs
@@ -12,14 +12,11 @@ public sealed partial class MainWindow : Window
 {
     private readonly INavigationService _navigationService;
 
-    public MainWindow()
+    public MainWindow(INavigationService navigationService)
     {
-        _navigationService = App.GetService<INavigationService>();
+        _navigationService = navigationService;
         InitializeComponent();
 
-        // TODO: Set the title bar icon by updating /Assets/WindowIcon.ico.
-        // A custom title bar is required for full window theme and Mica support.
-        // https://docs.microsoft.com/windows/apps/develop/title-bar?tabs=winui3#full-customization
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(TitleBar);
         TitleBar.Subtitle = Debugger.IsAttached ? "Debug" : "";
@@ -49,10 +46,7 @@ public sealed partial class MainWindow : Window
 
         _navigationService.Frame = NavigationFrame;
         _navigationService.InitializeNavigationView(NavigationViewControl);
-
         _navigationService.InitializeBreadcrumbBar(BreadcrumBarControl);
-
-        Closed += MainWindow_Closed;
     }
 
     private void NavViewTitleBar_BackRequested(Microsoft.UI.Xaml.Controls.TitleBar sender, object args)
@@ -72,38 +66,5 @@ public sealed partial class MainWindow : Window
     {
         var backgroundHoverColor = TitleBar.ActualTheme == ElementTheme.Dark ? Color.FromArgb(20, 255, 255, 255) : Color.FromArgb(40, 0, 0, 0);
         AppWindow.TitleBar.ButtonHoverBackgroundColor = backgroundHoverColor;
-    }
-
-    private async void MainWindow_Closed(object sender, WindowEventArgs args)
-    {
-        var presenter = AppWindow.Presenter as OverlappedPresenter;
-        var position = AppWindow.Position;
-        var size = AppWindow.Size;
-        var localSettings = App.GetService<ILocalSettingsService>();
-        await Task.Run(async () =>
-        {
-            if (presenter != null)
-            {
-                await localSettings.SaveSettingAsync("WindowState", (int)presenter.State);
-
-                if (presenter.State == OverlappedPresenterState.Restored)
-                {
-                    await localSettings.SaveSettingAsync("X", position.X);
-                    await localSettings.SaveSettingAsync("Y", position.Y);
-                    await localSettings.SaveSettingAsync("Width", size.Width);
-                    await localSettings.SaveSettingAsync("Height", size.Height);
-                }
-            }
-
-            //TODO: MapLocationFinder will make WinUI app hang on exit, more information on https://github.com/microsoft/microsoft-ui-xaml/issues/10229
-            try
-            {
-                Process.GetCurrentProcess().Kill();
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-            }
-        });
     }
 }

--- a/AutoDarkModeApp/MainWindow.xaml.cs
+++ b/AutoDarkModeApp/MainWindow.xaml.cs
@@ -20,6 +20,8 @@ public sealed partial class MainWindow : Window
         _navigationService = navigationService;
         InitializeComponent();
 
+        Title = Debugger.IsAttached ? "Auto Dark Mode Debug" : "Auto Dark Mode";
+
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(TitleBar);
         TitleBar.Subtitle = Debugger.IsAttached ? "Debug" : "";
@@ -27,11 +29,10 @@ public sealed partial class MainWindow : Window
 
         ApplySystemThemeToCaptionButtons();
 
-        AppWindow.SetIcon(Path.Combine(AppContext.BaseDirectory, "Assets/AutoDarkModeIcon.ico"));
-        AppWindow.SetTaskbarIcon(Path.Combine(AppContext.BaseDirectory, "Assets/AutoDarkModeIcon.ico"));
-        AppWindow.SetTitleBarIcon(Path.Combine(AppContext.BaseDirectory, "Assets/AutoDarkModeIcon.ico"));
-
-        Title = Debugger.IsAttached ? "Auto Dark Mode Debug" : "Auto Dark Mode";
+        var iconPath = Path.Combine(AppContext.BaseDirectory, "Assets/AutoDarkModeIcon.ico");
+        AppWindow.SetIcon(iconPath);
+        AppWindow.SetTaskbarIcon(iconPath);
+        AppWindow.SetTitleBarIcon(iconPath);
 
         IntPtr hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
         uint dpi = GetDpiForWindow(hwnd);

--- a/AutoDarkModeApp/Services/CloseService.cs
+++ b/AutoDarkModeApp/Services/CloseService.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using AutoDarkModeApp.Contracts.Services;
+﻿using AutoDarkModeApp.Contracts.Services;
 using Microsoft.UI.Windowing;
 
 namespace AutoDarkModeApp.Services;
@@ -8,33 +7,20 @@ public class CloseService(ILocalSettingsService localSettingsService) : ICloseSe
 {
     public async Task CloseAsync()
     {
-        var presenter = App.MainWindow.AppWindow.Presenter as OverlappedPresenter;
-        var position = App.MainWindow.AppWindow.Position;
-        var size = App.MainWindow.AppWindow.Size;
-        await Task.Run(async () =>
+        if (App.MainWindow.AppWindow.Presenter is OverlappedPresenter presenter)
         {
-            if (presenter is not null)
-            {
-                await localSettingsService.SaveSettingAsync("WindowState", (int)presenter.State);
+            var position = App.MainWindow.AppWindow.Position;
+            var size = App.MainWindow.AppWindow.Size;
 
-                if (presenter.State == OverlappedPresenterState.Restored)
-                {
-                    await localSettingsService.SaveSettingAsync("X", position.X);
-                    await localSettingsService.SaveSettingAsync("Y", position.Y);
-                    await localSettingsService.SaveSettingAsync("Width", size.Width);
-                    await localSettingsService.SaveSettingAsync("Height", size.Height);
-                }
-            }
+            await localSettingsService.SaveSettingAsync("WindowState", (int)presenter.State);
 
-            //NOTE: MapLocationFinder will make WinUI app hang on exit, more information on https://github.com/microsoft/microsoft-ui-xaml/issues/10229
-            try
+            if (presenter.State == OverlappedPresenterState.Restored)
             {
-                Process.GetCurrentProcess().Kill();
+                await localSettingsService.SaveSettingAsync("X", position.X);
+                await localSettingsService.SaveSettingAsync("Y", position.Y);
+                await localSettingsService.SaveSettingAsync("Width", size.Width);
+                await localSettingsService.SaveSettingAsync("Height", size.Height);
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.Message);
-            }
-        });
+        }
     }
 }

--- a/AutoDarkModeApp/Services/CloseService.cs
+++ b/AutoDarkModeApp/Services/CloseService.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics;
+using AutoDarkModeApp.Contracts.Services;
+using Microsoft.UI.Windowing;
+
+namespace AutoDarkModeApp.Services;
+
+public class CloseService(ILocalSettingsService localSettingsService) : ICloseService
+{
+    public async Task CloseAsync()
+    {
+        var presenter = App.MainWindow.AppWindow.Presenter as OverlappedPresenter;
+        var position = App.MainWindow.AppWindow.Position;
+        var size = App.MainWindow.AppWindow.Size;
+        await Task.Run(async () =>
+        {
+            if (presenter is not null)
+            {
+                await localSettingsService.SaveSettingAsync("WindowState", (int)presenter.State);
+
+                if (presenter.State == OverlappedPresenterState.Restored)
+                {
+                    await localSettingsService.SaveSettingAsync("X", position.X);
+                    await localSettingsService.SaveSettingAsync("Y", position.Y);
+                    await localSettingsService.SaveSettingAsync("Width", size.Width);
+                    await localSettingsService.SaveSettingAsync("Height", size.Height);
+                }
+            }
+
+            //NOTE: MapLocationFinder will make WinUI app hang on exit, more information on https://github.com/microsoft/microsoft-ui-xaml/issues/10229
+            try
+            {
+                Process.GetCurrentProcess().Kill();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Description

- Instead of the original MainWindow's Close event, a new **CloseService** is created to provide the closing service corresponding to **ActivationService**, so that `MainWindow.xaml.cs` will retain the specificity of its own window event and need not care about the closing event of the whole App.
- To improve code uniformity, the **MainWindow** was originally outside the DI container, and its life cycle could not be managed by the container.
- Use DI dependency injection for the window.