### PR TITLE
Refactor theme collection handler

### DIFF
--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -342,57 +342,6 @@ Would you like to create an issue on the Auto Dark Mode repository?</value>
   </data>
   <data name="FollowWindowsNightLight" xml:space="preserve">
     <value>Follow Windows night light</value>
-  </data>
-  <data name="AmbientLightSensor" xml:space="preserve">
-    <value>Ambient light sensor</value>
-  </data>
-  <data name="AmbientLightSensor_Description" xml:space="preserve">
-    <value>Automatically switch themes based on ambient light levels detected by your device's light sensor.</value>
-  </data>
-  <data name="AmbientLightThresholds" xml:space="preserve">
-    <value>Light thresholds</value>
-  </data>
-  <data name="AmbientLightThresholds_Header" xml:space="preserve">
-    <value>Configure light thresholds</value>
-  </data>
-  <data name="AmbientLightThresholds_Description" xml:space="preserve">
-    <value>This feature automatically switches the theme based on the brightness of your environment. Set the light levels (in lux) at which the theme should switch. Use different thresholds to prevent rapid switching.</value>
-  </data>
-  <data name="AmbientLightDarkThreshold" xml:space="preserve">
-    <value>Dark below (lux)</value>
-  </data>
-  <data name="AmbientLightLightThreshold" xml:space="preserve">
-    <value>Light above (lux)</value>
-  </data>
-  <data name="AmbientLightCurrentReading" xml:space="preserve">
-    <value>Current light level</value>
-  </data>
-  <data name="AmbientLightReference" xml:space="preserve">
-    <value>Light level reference guide</value>
-  </data>
-  <data name="AmbientLightRef_Moonlight" xml:space="preserve">
-    <value>Moonlight</value>
-  </data>
-  <data name="AmbientLightRef_VeryDark" xml:space="preserve">
-    <value>Very dark room</value>
-  </data>
-  <data name="AmbientLightRef_DimRoom" xml:space="preserve">
-    <value>Dimly lit room</value>
-  </data>
-  <data name="AmbientLightRef_LivingRoom" xml:space="preserve">
-    <value>Living room / bedroom</value>
-  </data>
-  <data name="AmbientLightRef_Office" xml:space="preserve">
-    <value>Office lighting</value>
-  </data>
-  <data name="AmbientLightRef_Overcast" xml:space="preserve">
-    <value>Overcast day indoors</value>
-  </data>
-  <data name="AmbientLightRef_DaylightShade" xml:space="preserve">
-    <value>Daylight (shade)</value>
-  </data>
-  <data name="AmbientLightRef_DirectSun" xml:space="preserve">
-    <value>Direct sunlight</value>
   </data>
   <data name="ForceDark" xml:space="preserve">
     <value>Force dark mode</value>
@@ -802,6 +751,7 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="Theme10_Flowers" xml:space="preserve">
     <value>Flowers</value>
+    <comment>Must match Windows theme name</comment>
   </data>
   <data name="Theme10_Windows" xml:space="preserve">
     <value>Windows</value>
@@ -814,15 +764,18 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="Theme11_CapturedMotion" xml:space="preserve">
     <value>Captured Motion</value>
+    <comment>Must match Win.11 theme name. File: themeB.theme</comment>
   </data>
   <data name="Theme11_Dark" xml:space="preserve">
     <value>Windows (Dark)</value>
   </data>
   <data name="Theme11_Flow" xml:space="preserve">
     <value>Flow</value>
+    <comment>Must match Win.11 theme name. File: themeD.theme</comment>
   </data>
   <data name="Theme11_Glow" xml:space="preserve">
     <value>Glow</value>
+    <comment>Must match Win.11 theme name. File: themeA.theme</comment>
   </data>
   <data name="Theme11_Light" xml:space="preserve">
     <value>Windows (Light)</value>
@@ -832,6 +785,7 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="Theme11_Sunrise" xml:space="preserve">
     <value>Sunrise</value>
+    <comment>Must match Win.11 theme name. File: themeC.theme</comment>
   </data>
   <data name="Time" xml:space="preserve">
     <value>Time</value>
@@ -1075,6 +1029,57 @@ Please note: This may introduce slight to moderate lag on some systems during th
   <data name="ShowTrayIcon" xml:space="preserve">
     <value>Show tray icon (recommended)</value>
   </data>
+  <data name="AmbientLightSensor" xml:space="preserve">
+    <value>Ambient light sensor</value>
+  </data>
+  <data name="AmbientLightSensor_Description" xml:space="preserve">
+    <value>Automatically switch themes based on ambient light levels detected by your device's light sensor.</value>
+  </data>
+  <data name="AmbientLightThresholds" xml:space="preserve">
+    <value>Light thresholds</value>
+  </data>
+  <data name="AmbientLightThresholds_Header" xml:space="preserve">
+    <value>Configure light thresholds</value>
+  </data>
+  <data name="AmbientLightThresholds_Description" xml:space="preserve">
+    <value>This feature automatically switches the theme based on the brightness of your environment. Set the light levels (in lux) at which the theme should switch. Use different thresholds to prevent rapid switching.</value>
+  </data>
+  <data name="AmbientLightDarkThreshold" xml:space="preserve">
+    <value>Dark below (lux)</value>
+  </data>
+  <data name="AmbientLightLightThreshold" xml:space="preserve">
+    <value>Light above (lux)</value>
+  </data>
+  <data name="AmbientLightCurrentReading" xml:space="preserve">
+    <value>Current light level</value>
+  </data>
+  <data name="AmbientLightReference" xml:space="preserve">
+    <value>Light level reference guide</value>
+  </data>
+  <data name="AmbientLightRef_Moonlight" xml:space="preserve">
+    <value>Moonlight</value>
+  </data>
+  <data name="AmbientLightRef_VeryDark" xml:space="preserve">
+    <value>Very dark room</value>
+  </data>
+  <data name="AmbientLightRef_DimRoom" xml:space="preserve">
+    <value>Dimly lit room</value>
+  </data>
+  <data name="AmbientLightRef_LivingRoom" xml:space="preserve">
+    <value>Living room / bedroom</value>
+  </data>
+  <data name="AmbientLightRef_Office" xml:space="preserve">
+    <value>Office lighting</value>
+  </data>
+  <data name="AmbientLightRef_Overcast" xml:space="preserve">
+    <value>Overcast day indoors</value>
+  </data>
+  <data name="AmbientLightRef_DaylightShade" xml:space="preserve">
+    <value>Daylight (shade)</value>
+  </data>
+  <data name="AmbientLightRef_DirectSun" xml:space="preserve">
+    <value>Direct sunlight</value>
+  </data>
   <data name="AmbientLightNoSensor" xml:space="preserve">
     <value>No sensor detected</value>
   </data>
@@ -1093,13 +1098,13 @@ Please note: This may introduce slight to moderate lag on some systems during th
   <data name="AmbientLightCurrent" xml:space="preserve">
     <value>Current:</value>
   </data>
-    <data name="DocumentationSocial" xml:space="preserve">
+  <data name="DocumentationSocial" xml:space="preserve">
     <value>Documentation &amp; Social</value>
   </data>
-    <data name="UsedSoftware" xml:space="preserve">
+  <data name="UsedSoftware" xml:space="preserve">
     <value>Used software</value>
   </data>
-    <data name="Diagnostics" xml:space="preserve">
+  <data name="Diagnostics" xml:space="preserve">
     <value>Diagnostics</value>
   </data>
   <data name="Contributors" xml:space="preserve">

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -36,21 +36,20 @@ public static class ThemeCollectionHandler
         { "theme2", "Theme10_Flowers".GetLocalized() }
     };
 
-    //  Get a list of all files the theme folder contains. If there is no theme-folder, create one.
+    //  Get a list of all userThemeFiles the theme folder contains. If there is no theme-folder, create one.
     public static List<ThemeFile> GetUserThemes()
     {
         try
         {
-            var files = Directory.EnumerateFiles(UserThemesFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
-            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
-
             var themeFiles = new List<ThemeFile>();
 
             // ---------------------------------------------------------
             // User themes
             // ---------------------------------------------------------
+            var userThemeFiles = Directory.EnumerateFiles(UserThemesFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
+            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
 
-            foreach (var file in files)
+            foreach (var file in userThemeFiles)
             {
                 string displayName = GetThemeDisplayName(file);
                 themeFiles.Add(new ThemeFile(file, displayName));
@@ -61,7 +60,6 @@ public static class ThemeCollectionHandler
             // ---------------------------------------------------------
             if (Directory.Exists(WindowsThemesFolderPath))
             {
-
                 foreach (var file in Directory.EnumerateFiles(WindowsThemesFolderPath, "*.theme", SearchOption.TopDirectoryOnly))
                 {
                     string displayName = GetThemeDisplayName(file).Trim();
@@ -75,7 +73,7 @@ public static class ThemeCollectionHandler
                         file.Contains(Helper.PathUnmanagedLightTheme) ||
                         file.Contains(Helper.PathManagedTheme)) continue;
 
-                    // Microsoft doesn’t store friendly names inside the .theme files
+                    // Microsoft doesn’t store friendly names inside the .theme userThemeFiles
                     // "DisplayName" inside the .theme file is not a friendly name
                     // If Windows stored a resource reference instead of a real name, ignore it
                     if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
@@ -141,12 +139,12 @@ public class ThemeFile(string path)
         : this(path)
     {
         Name = name;
-        IsWindowsTheme = true;
+        IsBuiltInWindowsTheme = true;
     }
 
     public string Path { get; } = path;
     public string Name { get; } = System.IO.Path.GetFileNameWithoutExtension(path) ?? "Undefined";
-    public bool IsWindowsTheme { get; }
+    public bool IsBuiltInWindowsTheme { get; }
 
     public override string ToString() => Name;
 

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -100,7 +100,8 @@ public static class ThemeCollectionHandler
                     themeFiles.Add(new ThemeFile(file, displayName));
                 }
             }
-            return themeFiles;
+
+            return themeFiles.OrderBy(t => t.Name).ToList();
         }
         catch
         {

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -15,15 +15,35 @@ public static class ThemeCollectionHandler
     public static readonly string ThemeFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Windows\Themes";
     public static readonly string WindowsPath = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
+    // friendly names for built-in Windows themes (because Windows does NOT store these anywhere)
+    private static readonly Dictionary<string, string> WindowsThemeNameOverrides = new()
+    {
+        // Windows 11
+        { "aero", "Theme11_Light".GetLocalized() },
+        { "dark", "Theme11_Dark".GetLocalized() },
+        { "themeA", "Theme11_Glow".GetLocalized() },
+        { "themeB", "Theme11_CapturedMotion".GetLocalized() },
+        { "themeC", "Theme11_Sunrise".GetLocalized() },
+        { "themeD", "Theme11_Flow".GetLocalized() },
+        { "spotlight", "Theme11_Spotlight".GetLocalized() },
+
+        // Windows 10
+        { "aero_Win10", "Theme10_Windows".GetLocalized() },          // same filename as Win11, different meaning
+        { "light", "Theme10_WindowsLight".GetLocalized() },
+        { "theme1", "Theme10_Windows10".GetLocalized() },
+        { "theme2", "Theme10_Flowers".GetLocalized() }
+    };
+
     //  Get a list of all files the theme folder contains. If there is no theme-folder, create one.
     public static List<ThemeFile> GetUserThemes()
     {
         try
         {
-            var files = Directory.EnumerateFiles(ThemeFolderPath, "*.theme", SearchOption.AllDirectories).ToList();
-            files = files.Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
+            var files = Directory.EnumerateFiles(ThemeFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
+            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
 
             var themeFiles = new List<ThemeFile>();
+
             foreach (var file in files)
             {
                 string displayName = GetThemeDisplayName(file);
@@ -40,9 +60,14 @@ public static class ThemeCollectionHandler
         }
     }
 
-    // Thanks Jay and Copilot
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetPrivateProfileString(string section, string key, string defaultValue, StringBuilder retVal, int size, string filePath);
+    private static extern int GetPrivateProfileString(
+        string section,
+        string key,
+        string defaultValue,
+        StringBuilder retVal,
+        int size,
+        string filePath);
 
     private static string GetThemeDisplayName(string themePath)
     {
@@ -50,7 +75,13 @@ public static class ThemeCollectionHandler
         {
             StringBuilder displayName = new StringBuilder(255);
             _ = GetPrivateProfileString("Theme", "DisplayName", "", displayName, displayName.Capacity, themePath);
-            return displayName.ToString();
+
+            string name = displayName.ToString();
+            if (!string.IsNullOrEmpty(name))
+                return name;
+
+            // fallback: filename
+            return Path.GetFileNameWithoutExtension(themePath) ?? "Undefined";
         }
         catch
         {
@@ -60,26 +91,47 @@ public static class ThemeCollectionHandler
 
     private static void InjectWindowsThemes(List<ThemeFile> themeFiles)
     {
-        if (Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_RC)
+        string themeFolder = Path.Combine(WindowsPath, @"Resources\Themes");
+
+        if (!Directory.Exists(themeFolder))
         {
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\aero.theme"), "Theme11_Light".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\dark.theme"), "Theme11_Dark".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\themeA.theme"), "Theme11_Glow".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\themeB.theme"), "Theme11_CapturedMotion".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\themeC.theme"), "Theme11_Sunrise".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\themeD.theme"), "Theme11_Flow".GetLocalized()));
-            ThemeFile spotlight = new(Path.Combine(WindowsPath, @"Resources\Themes\spotlight.theme"), "Theme11_Spotlight".GetLocalized());
-            if (File.Exists(spotlight.Path))
-            {
-                themeFiles.Add(spotlight);
-            }
+            return;
         }
-        else
+
+        var files = Directory.EnumerateFiles(themeFolder, "*.theme", SearchOption.TopDirectoryOnly);
+
+        foreach (var file in files)
         {
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\aero.theme"), "Theme10_Windows".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\Light.theme"), "Theme10_WindowsLight".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\theme1.theme"), "Theme10_Windows10".GetLocalized()));
-            themeFiles.Add(new ThemeFile(Path.Combine(WindowsPath, @"Resources\Themes\theme2.theme"), "Theme10_Flowers".GetLocalized()));
+            string displayName = GetThemeDisplayName(file).Trim();
+            string fileName = Path.GetFileNameWithoutExtension(file);
+            //string key = fileName.ToLowerInvariant();
+            bool isWin11 = Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_RC;
+            string lookupKey = fileName;
+
+            // skip ADM-managed themes
+            if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
+                file.Contains(Helper.PathUnmanagedLightTheme) ||
+                file.Contains(Helper.PathManagedTheme)) continue;
+
+            // Microsoft doesn’t store friendly names inside the .theme files
+            // The problem is DisplayName inside the .theme file is not a friendly name
+            // If Windows stored a resource reference instead of a real name, ignore it
+            if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
+                displayName = "";
+
+            if (!isWin11 && fileName == "aero")
+            {
+                lookupKey = "aero_Win10"; // rename for Windows 10
+            }
+
+            // fallback to filename if display name is empty
+            if (string.IsNullOrEmpty(displayName) && WindowsThemeNameOverrides.TryGetValue(lookupKey, out string friendly))
+                displayName = friendly;
+
+            if (string.IsNullOrEmpty(displayName))
+                displayName = fileName;
+
+            themeFiles.Add(new ThemeFile(file, displayName));
         }
     }
 }
@@ -97,18 +149,12 @@ public class ThemeFile(string path)
     public string Name { get; } = System.IO.Path.GetFileNameWithoutExtension(path) ?? "Undefined";
     public bool IsWindowsTheme { get; }
 
-    public override string ToString()
-    {
-        return Name;
-    }
+    public override string ToString() => Name;
 
     public override bool Equals(object? obj)
     {
         return obj is string name ? Name.Equals(name, StringComparison.Ordinal) : base.Equals(obj);
     }
 
-    public override int GetHashCode()
-    {
-        return Name.GetHashCode();
-    }
+    public override int GetHashCode() => Name.GetHashCode();
 }

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -47,12 +47,19 @@ public static class ThemeCollectionHandler
             // User themes
             // ---------------------------------------------------------
             var userThemeFiles = Directory.EnumerateFiles(UserThemesFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
-            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
+            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.PathUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
 
             foreach (var file in userThemeFiles)
             {
                 string displayName = GetThemeDisplayName(file);
-                themeFiles.Add(new ThemeFile(file, displayName));
+                if (!string.IsNullOrEmpty(displayName))
+                {
+                    themeFiles.Add(new ThemeFile(file, displayName));
+                }
+                else
+                {
+                    themeFiles.Add(new ThemeFile(file)); // fallback to filename if display name is empty
+                }
             }
 
             // ---------------------------------------------------------
@@ -71,7 +78,8 @@ public static class ThemeCollectionHandler
                     // skip ADM-managed themes
                     if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
                         file.Contains(Helper.PathUnmanagedLightTheme) ||
-                        file.Contains(Helper.PathManagedTheme)) continue;
+                        file.Contains(Helper.PathManagedTheme))
+                        continue;
 
                     // Microsoft doesn’t store friendly names inside the .theme userThemeFiles
                     // "DisplayName" inside the .theme file is not a friendly name
@@ -79,7 +87,7 @@ public static class ThemeCollectionHandler
                     if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
                         displayName = "";
 
-                    if (!isWin11 && fileName == "aero")
+                    if (!isWin11 && fileName.Equals("aero", StringComparison.OrdinalIgnoreCase))
                     {
                         lookupKey = "aero_Win10"; // rename for Windows 10
                     }
@@ -123,35 +131,35 @@ public static class ThemeCollectionHandler
             if (!string.IsNullOrEmpty(name))
                 return name;
 
-            // fallback: filename
-            return Path.GetFileNameWithoutExtension(themePath) ?? "Undefined";
+            // return empty so caller can decide fallback
+            return "";
         }
         catch
         {
-            return Path.GetFileNameWithoutExtension(themePath) ?? "Undefined";
+            return "";
         }
     }
 }
 
-public class ThemeFile(string path)
+public class ThemeFile
 {
-    public ThemeFile(string path, string name)
-        : this(path)
+    public ThemeFile(string path)
     {
+        Path = path;
+        Name = System.IO.Path.GetFileNameWithoutExtension(path);
+        IsBuiltInWindowsTheme = false;
+    }
+
+    public ThemeFile(string path, string name)
+    {
+        Path = path;
         Name = name;
         IsBuiltInWindowsTheme = true;
     }
 
-    public string Path { get; } = path;
-    public string Name { get; } = System.IO.Path.GetFileNameWithoutExtension(path) ?? "Undefined";
+    public string Path { get; }
+    public string Name { get; }
     public bool IsBuiltInWindowsTheme { get; }
 
     public override string ToString() => Name;
-
-    public override bool Equals(object? obj)
-    {
-        return obj is string name ? Name.Equals(name, StringComparison.Ordinal) : base.Equals(obj);
-    }
-
-    public override int GetHashCode() => Name.GetHashCode();
 }

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -12,11 +12,6 @@ namespace AutoDarkModeApp.Utils.Handlers;
 
 public static class ThemeCollectionHandler
 {
-    public static readonly string UserThemesFolderPath =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes");
-    public static readonly string WindowsThemesFolderPath =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Resources", "Themes");
-
     // friendly names for built-in Windows themes (because Windows does NOT store these anywhere)
     private static readonly Dictionary<string, string> WindowsThemeNameOverrides = new()
     {
@@ -36,7 +31,7 @@ public static class ThemeCollectionHandler
         { "theme2", "Theme10_Flowers".GetLocalized() }
     };
 
-    //  Get a list of all userThemeFiles the theme folder contains. If there is no theme-folder, create one.
+    //  Get a list of all theme files the theme folder contains. If there is no theme-folder, create one.
     public static List<ThemeFile> GetUserThemes()
     {
         try
@@ -46,8 +41,11 @@ public static class ThemeCollectionHandler
             // ---------------------------------------------------------
             // User themes
             // ---------------------------------------------------------
-            var userThemeFiles = Directory.EnumerateFiles(UserThemesFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
-            .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.PathUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
+            var userThemeFiles = Directory.EnumerateFiles(Helper.UserThemesFolderPath, "*.theme", SearchOption.AllDirectories)
+                .Where(f => !f.Equals(Helper.UnmanagedDarkThemePath, StringComparison.OrdinalIgnoreCase) &&
+                    !f.Equals(Helper.UnmanagedLightThemePath, StringComparison.OrdinalIgnoreCase) &&
+                    !f.Equals(Helper.ManagedThemePath, StringComparison.OrdinalIgnoreCase))
+                .ToList();
 
             foreach (var file in userThemeFiles)
             {
@@ -65,23 +63,23 @@ public static class ThemeCollectionHandler
             // ---------------------------------------------------------
             // Built‑in Windows themes (Win10 + Win11)
             // ---------------------------------------------------------
-            if (Directory.Exists(WindowsThemesFolderPath))
+            if (Directory.Exists(Helper.WindowsThemesFolderPath))
             {
-                foreach (var file in Directory.EnumerateFiles(WindowsThemesFolderPath, "*.theme", SearchOption.TopDirectoryOnly))
+                foreach (var file in Directory.EnumerateFiles(Helper.WindowsThemesFolderPath, "*.theme", SearchOption.TopDirectoryOnly))
                 {
+                    // skip ADM-managed themes
+                    if (file.Contains(Helper.UnmanagedDarkThemePath) ||
+                        file.Contains(Helper.UnmanagedLightThemePath) ||
+                        file.Contains(Helper.ManagedThemePath))
+                        continue;
+
                     string displayName = GetThemeDisplayName(file).Trim();
                     string fileName = Path.GetFileNameWithoutExtension(file);
 
                     bool isWin11 = Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_RC;
                     string lookupKey = fileName;
 
-                    // skip ADM-managed themes
-                    if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
-                        file.Contains(Helper.PathUnmanagedLightTheme) ||
-                        file.Contains(Helper.PathManagedTheme))
-                        continue;
-
-                    // Microsoft doesn’t store friendly names inside the .theme userThemeFiles
+                    // Microsoft doesn’t store friendly names inside the .theme theme files
                     // "DisplayName" inside the .theme file is not a friendly name
                     // If Windows stored a resource reference instead of a real name, ignore it
                     if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
@@ -106,7 +104,7 @@ public static class ThemeCollectionHandler
         }
         catch
         {
-            Directory.CreateDirectory(UserThemesFolderPath);
+            Directory.CreateDirectory(Helper.UserThemesFolderPath);
             return GetUserThemes();
         }
     }

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -44,13 +44,58 @@ public static class ThemeCollectionHandler
 
             var themeFiles = new List<ThemeFile>();
 
+            // ---------------------------------------------------------
+            // User themes
+            // ---------------------------------------------------------
+
             foreach (var file in files)
             {
                 string displayName = GetThemeDisplayName(file);
                 themeFiles.Add(new ThemeFile(file, displayName));
             }
 
-            InjectWindowsThemes(themeFiles);
+            // ---------------------------------------------------------
+            // Built‑in Windows themes (Win10 + Win11)
+            // ---------------------------------------------------------
+            string themeFolder = Path.Combine(WindowsPath, @"Resources\Themes");
+
+            if (Directory.Exists(themeFolder))
+            {
+
+                foreach (var file in Directory.EnumerateFiles(themeFolder, "*.theme", SearchOption.TopDirectoryOnly))
+                {
+                    string displayName = GetThemeDisplayName(file).Trim();
+                    string fileName = Path.GetFileNameWithoutExtension(file);
+
+                    bool isWin11 = Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_RC;
+                    string lookupKey = fileName;
+
+                    // skip ADM-managed themes
+                    if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
+                        file.Contains(Helper.PathUnmanagedLightTheme) ||
+                        file.Contains(Helper.PathManagedTheme)) continue;
+
+                    // Microsoft doesn’t store friendly names inside the .theme files
+                    // "DisplayName" inside the .theme file is not a friendly name
+                    // If Windows stored a resource reference instead of a real name, ignore it
+                    if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
+                        displayName = "";
+
+                    if (!isWin11 && fileName == "aero")
+                    {
+                        lookupKey = "aero_Win10"; // rename for Windows 10
+                    }
+
+                    if (string.IsNullOrEmpty(displayName) && WindowsThemeNameOverrides.TryGetValue(lookupKey, out string friendly))
+                        displayName = friendly;
+
+                    // fallback to filename if display name is empty
+                    if (string.IsNullOrEmpty(displayName))
+                        displayName = fileName;
+
+                    themeFiles.Add(new ThemeFile(file, displayName));
+                }
+            }
             return themeFiles;
         }
         catch
@@ -86,52 +131,6 @@ public static class ThemeCollectionHandler
         catch
         {
             return Path.GetFileNameWithoutExtension(themePath) ?? "Undefined";
-        }
-    }
-
-    private static void InjectWindowsThemes(List<ThemeFile> themeFiles)
-    {
-        string themeFolder = Path.Combine(WindowsPath, @"Resources\Themes");
-
-        if (!Directory.Exists(themeFolder))
-        {
-            return;
-        }
-
-        var files = Directory.EnumerateFiles(themeFolder, "*.theme", SearchOption.TopDirectoryOnly);
-
-        foreach (var file in files)
-        {
-            string displayName = GetThemeDisplayName(file).Trim();
-            string fileName = Path.GetFileNameWithoutExtension(file);
-            //string key = fileName.ToLowerInvariant();
-            bool isWin11 = Environment.OSVersion.Version.Build >= (int)WindowsBuilds.Win11_RC;
-            string lookupKey = fileName;
-
-            // skip ADM-managed themes
-            if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
-                file.Contains(Helper.PathUnmanagedLightTheme) ||
-                file.Contains(Helper.PathManagedTheme)) continue;
-
-            // Microsoft doesn’t store friendly names inside the .theme files
-            // The problem is DisplayName inside the .theme file is not a friendly name
-            // If Windows stored a resource reference instead of a real name, ignore it
-            if (displayName.StartsWith("@%SystemRoot%", StringComparison.OrdinalIgnoreCase))
-                displayName = "";
-
-            if (!isWin11 && fileName == "aero")
-            {
-                lookupKey = "aero_Win10"; // rename for Windows 10
-            }
-
-            // fallback to filename if display name is empty
-            if (string.IsNullOrEmpty(displayName) && WindowsThemeNameOverrides.TryGetValue(lookupKey, out string friendly))
-                displayName = friendly;
-
-            if (string.IsNullOrEmpty(displayName))
-                displayName = fileName;
-
-            themeFiles.Add(new ThemeFile(file, displayName));
         }
     }
 }

--- a/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
+++ b/AutoDarkModeApp/Utils/Handlers/ThemeCollectionHandler.cs
@@ -12,8 +12,10 @@ namespace AutoDarkModeApp.Utils.Handlers;
 
 public static class ThemeCollectionHandler
 {
-    public static readonly string ThemeFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Windows\Themes";
-    public static readonly string WindowsPath = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+    public static readonly string UserThemesFolderPath =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes");
+    public static readonly string WindowsThemesFolderPath =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Resources", "Themes");
 
     // friendly names for built-in Windows themes (because Windows does NOT store these anywhere)
     private static readonly Dictionary<string, string> WindowsThemeNameOverrides = new()
@@ -39,7 +41,7 @@ public static class ThemeCollectionHandler
     {
         try
         {
-            var files = Directory.EnumerateFiles(ThemeFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
+            var files = Directory.EnumerateFiles(UserThemesFolderPath, "*.theme", SearchOption.AllDirectories).ToList()
             .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
 
             var themeFiles = new List<ThemeFile>();
@@ -57,12 +59,10 @@ public static class ThemeCollectionHandler
             // ---------------------------------------------------------
             // Built‑in Windows themes (Win10 + Win11)
             // ---------------------------------------------------------
-            string themeFolder = Path.Combine(WindowsPath, @"Resources\Themes");
-
-            if (Directory.Exists(themeFolder))
+            if (Directory.Exists(WindowsThemesFolderPath))
             {
 
-                foreach (var file in Directory.EnumerateFiles(themeFolder, "*.theme", SearchOption.TopDirectoryOnly))
+                foreach (var file in Directory.EnumerateFiles(WindowsThemesFolderPath, "*.theme", SearchOption.TopDirectoryOnly))
                 {
                     string displayName = GetThemeDisplayName(file).Trim();
                     string fileName = Path.GetFileNameWithoutExtension(file);
@@ -100,7 +100,7 @@ public static class ThemeCollectionHandler
         }
         catch
         {
-            Directory.CreateDirectory(ThemeFolderPath);
+            Directory.CreateDirectory(UserThemesFolderPath);
             return GetUserThemes();
         }
     }

--- a/AutoDarkModeApp/ViewModels/ThemePickerViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/ThemePickerViewModel.cs
@@ -24,10 +24,11 @@ public partial class ThemePickerViewModel : ObservableRecipient
     public partial bool ThemeKeepActiveEnabled { get; set; }
 
     [ObservableProperty]
-    public partial object? SelectedLightTheme { get; set; }
+    public partial ThemeFile? SelectedLightTheme { get; set; }
 
     [ObservableProperty]
-    public partial object? SelectedDarkTheme { get; set; }
+    public partial ThemeFile? SelectedDarkTheme { get; set; }
+
 
     [ObservableProperty]
     public partial bool IgnoreBackgroundEnabled { get; set; }
@@ -155,26 +156,14 @@ public partial class ThemePickerViewModel : ObservableRecipient
         }
     }
 
-    partial void OnSelectedLightThemeChanged(object? value)
+    partial void OnSelectedLightThemeChanged(ThemeFile? value)
     {
-        if (_isInitializing)
+        if (_isInitializing || value == null)
             return;
 
-        List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
-        IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString());
-        try
-        {
-            if (value != null)
-            {
-                ThemeFile? selected = themeCollection.FirstOrDefault(t => t.ToString().Contains(value.ToString()!));
-                if (selected != null)
-                    _builder.Config.WindowsThemeMode.LightThemePath = selected.Path;
-            }
-        }
-        catch
-        {
-            SelectedLightTheme = null;
-        }
+        _builder.Config.WindowsThemeMode.LightThemePath = value.Path;
+        //List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
+        //IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString());
 
         if (ThemeSwitchEnabled)
         {
@@ -193,26 +182,14 @@ public partial class ThemePickerViewModel : ObservableRecipient
         RequestThemeSwitch();
     }
 
-    partial void OnSelectedDarkThemeChanged(object? value)
+    partial void OnSelectedDarkThemeChanged(ThemeFile? value)
     {
-        if (_isInitializing)
+        if (_isInitializing || value == null)
             return;
 
-        List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
-        IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString());
-        try
-        {
-            if (value != null)
-            {
-                ThemeFile? selected = themeCollection.FirstOrDefault(t => t.ToString().Contains(value.ToString()!));
-                if (selected != null)
-                    _builder.Config.WindowsThemeMode.DarkThemePath = selected.Path;
-            }
-        }
-        catch
-        {
-            SelectedDarkTheme = null;
-        }
+        _builder.Config.WindowsThemeMode.DarkThemePath = value.Path;
+        //List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
+        //IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString());
 
         if (ThemeSwitchEnabled)
         {

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml
@@ -49,6 +49,7 @@
                     Click="OpenThemeFolderSettingsCard_Click"
                     Header="{helpers:ResourceString Name=OpenPath}"
                     IsClickEnabled="True"
+                    ToolTipService.ToolTip="{x:Bind UserThemesFolderPath}"
                     IsEnabled="{x:Bind ViewModel.ThemeSwitchEnabled, Mode=OneWay}" />
 
                 <!--  Ignore  -->

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml
@@ -55,10 +55,10 @@
                 <!--  Ignore  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=IgnoreSettings}" />
 
-                <InfoBar
-                    IsClosable="False"
-                    IsOpen="True"
-                    Message="{helpers:ResourceString Name=Msg_IgnoreDisabled}" />
+                <StackPanel Spacing="8" Orientation="Horizontal" Margin="0,8,0,0">
+                    <FontIcon Glyph="&#xF167;" FontSize="{StaticResource BodyTextBlockFontSize}" Foreground="{ThemeResource SystemFillColorAttentionBrush}" />
+                    <TextBlock Text="{helpers:ResourceString Name=Msg_IgnoreDisabled}" />
+                </StackPanel>
 
                 <controls:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind ViewModel.ThemeSwitchEnabled, Mode=OneWay}">
                     <CheckBox Content="{helpers:ResourceString Name=IgnoreBackground}" IsChecked="{x:Bind ViewModel.IgnoreBackgroundEnabled, Mode=TwoWay}" />

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
@@ -8,6 +8,7 @@ namespace AutoDarkModeApp.Views;
 
 public sealed partial class ThemePickerPage : Page
 {
+    public string UserThemesFolderPath => ThemeCollectionHandler.UserThemesFolderPath;
     private readonly AdmConfigBuilder _builder = AdmConfigBuilder.Instance();
 
     public ThemePickerViewModel ViewModel { get; }
@@ -41,7 +42,7 @@ public sealed partial class ThemePickerPage : Page
 
     private void OpenThemeFolderSettingsCard_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        var themeFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Windows\Themes";
+        var themeFolderPath = ThemeCollectionHandler.UserThemesFolderPath;
         Directory.CreateDirectory(themeFolderPath);
         Process.Start(new ProcessStartInfo(themeFolderPath) { UseShellExecute = true, Verb = "open" });
     }

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
@@ -23,33 +23,26 @@ public sealed partial class ThemePickerPage : Page
     private void LoadThemes()
     {
         List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
-        IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString()).ToList();
-        LightThemeComboBox.ItemsSource = themeNames;
-        DarkThemeComboBox.ItemsSource = themeNames;
+        //IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString()).ToList();
+        LightThemeComboBox.ItemsSource = themeCollection;
+        DarkThemeComboBox.ItemsSource = themeCollection;
         ThemeFile? lightSelected = themeCollection.FirstOrDefault(t => t.Path == _builder.Config.WindowsThemeMode.LightThemePath);
         ThemeFile? darkSelected = themeCollection.FirstOrDefault(t => t.Path == _builder.Config.WindowsThemeMode.DarkThemePath);
         if (lightSelected != null)
         {
-            ViewModel.SelectedLightTheme = lightSelected.ToString();
+            ViewModel.SelectedLightTheme = lightSelected;
         }
 
         if (darkSelected != null)
         {
-            ViewModel.SelectedDarkTheme = darkSelected.ToString();
+            ViewModel.SelectedDarkTheme = darkSelected;
         }
     }
 
     private void OpenThemeFolderSettingsCard_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
         var themeFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\Windows\Themes";
-        try
-        {
-            Process.Start(new ProcessStartInfo(themeFolderPath) { UseShellExecute = true, Verb = "open" });
-        }
-        catch
-        {
-            Directory.CreateDirectory(themeFolderPath);
-            Process.Start(new ProcessStartInfo(themeFolderPath) { UseShellExecute = true, Verb = "open" });
-        }
+        Directory.CreateDirectory(themeFolderPath);
+        Process.Start(new ProcessStartInfo(themeFolderPath) { UseShellExecute = true, Verb = "open" });
     }
 }

--- a/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ThemePickerPage.xaml.cs
@@ -8,7 +8,7 @@ namespace AutoDarkModeApp.Views;
 
 public sealed partial class ThemePickerPage : Page
 {
-    public string UserThemesFolderPath => ThemeCollectionHandler.UserThemesFolderPath;
+    public string UserThemesFolderPath => Helper.UserThemesFolderPath;
     private readonly AdmConfigBuilder _builder = AdmConfigBuilder.Instance();
 
     public ThemePickerViewModel ViewModel { get; }
@@ -24,7 +24,6 @@ public sealed partial class ThemePickerPage : Page
     private void LoadThemes()
     {
         List<ThemeFile> themeCollection = ThemeCollectionHandler.GetUserThemes();
-        //IEnumerable<string> themeNames = themeCollection.Select(t => t.ToString()).ToList();
         LightThemeComboBox.ItemsSource = themeCollection;
         DarkThemeComboBox.ItemsSource = themeCollection;
         ThemeFile? lightSelected = themeCollection.FirstOrDefault(t => t.Path == _builder.Config.WindowsThemeMode.LightThemePath);
@@ -42,7 +41,7 @@ public sealed partial class ThemePickerPage : Page
 
     private void OpenThemeFolderSettingsCard_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
-        var themeFolderPath = ThemeCollectionHandler.UserThemesFolderPath;
+        var themeFolderPath = Helper.UserThemesFolderPath;
         Directory.CreateDirectory(themeFolderPath);
         Process.Start(new ProcessStartInfo(themeFolderPath) { UseShellExecute = true, Verb = "open" });
     }

--- a/AutoDarkModeLib/Helper.cs
+++ b/AutoDarkModeLib/Helper.cs
@@ -42,13 +42,14 @@ public static class Helper
     public static readonly string ExecutionDirUpdater = GetExecutionDirUpdater();
     public static readonly string ExecutionPathService = GetExecutionPathService();
     public static readonly string UpdateDataDir = GetUpdateDataDir();
-    public static string PathThemeFolder { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes");
-    public static string PathManagedTheme { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes", "ADMTheme.theme");
-    public static string PathDwmRefreshTheme { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes", "DwmRefreshTheme.theme");
-    public static string PathUnmanagedDarkTheme { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes", "ADMUnmanagedDark.theme");
-    public static string PathUnmanagedLightTheme { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes", "ADMUnmanagedLight.theme");
-    public static string NameUnmanagedLightTheme { get; } = "ADMUnmanagedLight";
-    public static string NameUnmanagedDarkTheme { get; } = "ADMUnmanagedDark";
+    public static string UnmanagedLightThemeName { get; } = "ADMUnmanagedLight";
+    public static string UnmanagedDarkThemeName { get; } = "ADMUnmanagedDark";
+    public static string UserThemesFolderPath { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Themes");
+    public static string ManagedThemePath { get; } = Path.Combine(UserThemesFolderPath, "ADMTheme.theme");
+    public static string DwmRefreshThemePath { get; } = Path.Combine(UserThemesFolderPath, "DwmRefreshTheme.theme");
+    public static string UnmanagedLightThemePath { get; } = Path.Combine(UserThemesFolderPath, $"{UnmanagedLightThemeName}.theme");
+    public static string UnmanagedDarkThemePath { get; } = Path.Combine(UserThemesFolderPath, $"{UnmanagedDarkThemeName}.theme");
+    public static string WindowsThemesFolderPath { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Resources", "Themes");
     public static string Hegex { get; } = @"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$";
 
     public static bool NowIsBetweenTimes(TimeSpan start, TimeSpan end)

--- a/AutoDarkModeSvc/Core/GlobalState.cs
+++ b/AutoDarkModeSvc/Core/GlobalState.cs
@@ -66,7 +66,7 @@ public class GlobalState
     }
     public Theme ForcedTheme { get; set; } = Theme.Unknown;
     public string UnmanagedActiveThemePath { get; set; } = "";
-    public ThemeFile ManagedThemeFile { get; } = new(Helper.PathManagedTheme);
+    public ThemeFile ManagedThemeFile { get; } = new(Helper.ManagedThemePath);
     public PostponeManager PostponeManager { get; }
     public NightLight NightLight { get; } = new();
     public AmbientLightState AmbientLight { get; } = new();
@@ -122,7 +122,7 @@ public class GlobalState
                 // persists because we have set it originally when applying the theme, so if we read that then we are aware of the origin theme
                 if (config.WindowsThemeMode.ApplyFlags != null && config.WindowsThemeMode.ApplyFlags.Count > 0)
                 {
-                    string customPath = Path.Combine(Helper.PathThemeFolder, "Custom.theme");
+                    string customPath = Path.Combine(Helper.UserThemesFolderPath, "Custom.theme");
                     bool unmanagedCustom = UnmanagedActiveThemePath.Equals(customPath);
                     if (unmanagedCustom)
                     {
@@ -133,11 +133,11 @@ public class GlobalState
                         string sourceThemeNameCustom = ThemeFile.GetOriginalNameFromRaw(customPath);
                         if (sourceThemeNameCustom == displayNameDark)
                         {
-                            UnmanagedActiveThemePath = Helper.PathUnmanagedDarkTheme;
+                            UnmanagedActiveThemePath = Helper.UnmanagedDarkThemePath;
                         }
                         else if (sourceThemeNameCustom == displayNameLight)
                         {
-                            UnmanagedActiveThemePath = Helper.PathUnmanagedLightTheme;
+                            UnmanagedActiveThemePath = Helper.UnmanagedLightThemePath;
                         }
                         Logger.Debug($"refresh theme state with apply flags enabled, active theme: {(UnmanagedActiveThemePath == "" ? "undefined" : UnmanagedActiveThemePath)}");
                     }
@@ -145,14 +145,14 @@ public class GlobalState
                 // for unmanaged without applyflags
                 else
                 {
-                    bool unmanagedLight = UnmanagedActiveThemePath.Equals(Helper.PathUnmanagedLightTheme);
-                    bool unmanagedDark = UnmanagedActiveThemePath.Equals(Helper.PathUnmanagedDarkTheme);
+                    bool unmanagedLight = UnmanagedActiveThemePath.Equals(Helper.UnmanagedLightThemePath);
+                    bool unmanagedDark = UnmanagedActiveThemePath.Equals(Helper.UnmanagedDarkThemePath);
 
                     // check if an unmanaged theme is active. If so, extract the original name from the theme path
                     // This way, we know which origin theme is active and don't have to switch
                     if (unmanagedLight)
                     {
-                        string displayNameUnmanaged = ThemeFile.GetOriginalNameFromRaw(Helper.PathUnmanagedLightTheme);
+                        string displayNameUnmanaged = ThemeFile.GetOriginalNameFromRaw(Helper.UnmanagedLightThemePath);
                         (_, _, string displayNameSource) = ThemeFile.GetDisplayNameFromRaw(config.WindowsThemeMode.LightThemePath);
                         if (displayNameUnmanaged != displayNameSource)
                         {
@@ -162,7 +162,7 @@ public class GlobalState
                     }
                     if (unmanagedDark)
                     {
-                        string displayNameUnmanaged = ThemeFile.GetOriginalNameFromRaw(Helper.PathUnmanagedDarkTheme);
+                        string displayNameUnmanaged = ThemeFile.GetOriginalNameFromRaw(Helper.UnmanagedDarkThemePath);
                         (_, _, string displayNameSource) = ThemeFile.GetDisplayNameFromRaw(config.WindowsThemeMode.DarkThemePath);
                         if (displayNameUnmanaged != displayNameSource)
                         {

--- a/AutoDarkModeSvc/Handlers/DwmRefreshHandler.cs
+++ b/AutoDarkModeSvc/Handlers/DwmRefreshHandler.cs
@@ -151,7 +151,7 @@ internal sealed partial class DwmRefreshHandler
         try
         {
             // prepare theme
-            ThemeFile dwmRefreshTheme = new(Helper.PathDwmRefreshTheme);
+            ThemeFile dwmRefreshTheme = new(Helper.DwmRefreshThemePath);
             bool managed = !builder.Config.WindowsThemeMode.Enabled;
             if (!managed)
             {

--- a/AutoDarkModeSvc/Handlers/RegistryHandler.cs
+++ b/AutoDarkModeSvc/Handlers/RegistryHandler.cs
@@ -151,7 +151,7 @@ static class RegistryHandler
         // call first becaues it refreshes the regkey
         (bool isCustom, string activeThemeName) = Tm2Handler.GetActiveThemeName();
         using RegistryKey key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes");
-        string themePath = (string)key.GetValue("CurrentTheme") ?? new(Path.Combine(Helper.PathThemeFolder, "Custom.theme"));
+        string themePath = (string)key.GetValue("CurrentTheme") ?? new(Path.Combine(Helper.UserThemesFolderPath, "Custom.theme"));
 
         ThemeFile tempTheme = null;
         if (themePath.Length > 0)
@@ -177,7 +177,7 @@ static class RegistryHandler
         {
             // if the name of the retrieved theme doesn't match, we will just select the custom theme as fallback
             Logger.Debug($"expected name: {activeThemeName} different from display name: {tempTheme.DisplayName} with path: {themePath}");
-            themePath = new(Path.Combine(Helper.PathThemeFolder, "Custom.theme"));
+            themePath = new(Path.Combine(Helper.UserThemesFolderPath, "Custom.theme"));
         }
         else
         {

--- a/AutoDarkModeSvc/Handlers/ThemeFiles/ThemeFile.cs
+++ b/AutoDarkModeSvc/Handlers/ThemeFiles/ThemeFile.cs
@@ -259,7 +259,7 @@ public partial class ThemeFile
     {
         try
         {
-            string customPath = Path.Combine(Helper.PathThemeFolder, "Custom.theme");
+            string customPath = Path.Combine(Helper.UserThemesFolderPath, "Custom.theme");
 
             // call first becaues it refreshes the regkey
             (bool isCustom, string activeThemeName) = Tm2Handler.GetActiveThemeName();

--- a/AutoDarkModeSvc/Handlers/ThemeHandler.cs
+++ b/AutoDarkModeSvc/Handlers/ThemeHandler.cs
@@ -68,9 +68,9 @@ public static class ThemeHandler
 
         if (newTheme == Theme.Light)
         {
-            ThemeFile light = ThemeFile.LoadUnmanagedTheme(builder.Config.WindowsThemeMode.LightThemePath, Helper.PathUnmanagedLightTheme);
+            ThemeFile light = ThemeFile.LoadUnmanagedTheme(builder.Config.WindowsThemeMode.LightThemePath, Helper.UnmanagedLightThemePath);
             light.UnmanagedOriginalName = light.DisplayName;
-            light.DisplayName = Helper.NameUnmanagedLightTheme;
+            light.DisplayName = Helper.UnmanagedLightThemeName;
             if (light.Colors.InfoText.Item1 == state.ManagedThemeFile.Colors.InfoText.Item1)
             {
                 ThemeFile.PatchColorsWin11AndSave(light);
@@ -83,9 +83,9 @@ public static class ThemeHandler
         }
         else if (newTheme == Theme.Dark)
         {
-            ThemeFile dark = ThemeFile.LoadUnmanagedTheme(builder.Config.WindowsThemeMode.DarkThemePath, Helper.PathUnmanagedDarkTheme);
+            ThemeFile dark = ThemeFile.LoadUnmanagedTheme(builder.Config.WindowsThemeMode.DarkThemePath, Helper.UnmanagedDarkThemePath);
             dark.UnmanagedOriginalName = dark.DisplayName;
-            dark.DisplayName = Helper.NameUnmanagedDarkTheme;
+            dark.DisplayName = Helper.UnmanagedDarkThemeName;
             if (dark.Colors.InfoText.Item1 == state.ManagedThemeFile.Colors.InfoText.Item1)
             {
                 ThemeFile.PatchColorsWin11AndSave(dark);
@@ -117,11 +117,11 @@ public static class ThemeHandler
         switch (theme)
         {
             case Theme.Light:
-                themePath = Helper.PathUnmanagedLightTheme;
+                themePath = Helper.UnmanagedLightThemePath;
                 break;
 
             case Theme.Dark:
-                themePath = Helper.PathUnmanagedDarkTheme;
+                themePath = Helper.UnmanagedDarkThemePath;
                 break;
         }
         if (builder.Config.WindowsThemeMode.Enabled
@@ -194,12 +194,12 @@ public static class ThemeHandler
 
         // TODO: change tracking when having active theme monitor disabled
         if (newTheme == Theme.Dark && (skipCheck ||
-            (!state.UnmanagedActiveThemePath.Equals(Helper.PathUnmanagedDarkTheme))))
+            (!state.UnmanagedActiveThemePath.Equals(Helper.UnmanagedDarkThemePath))))
         {
             return true;
         }
         else if (newTheme == Theme.Light && (skipCheck ||
-            (!state.UnmanagedActiveThemePath.Equals(Helper.PathUnmanagedLightTheme))))
+            (!state.UnmanagedActiveThemePath.Equals(Helper.UnmanagedLightThemePath))))
         {
             return true;
         }


### PR DESCRIPTION
fixes #1208

Refactored the handler to search for .theme files, also in the Windows Themes folder.
Note that the `DisplayName` is not a friendly string inside the built-in Windows themes, so I used a look-up table to connect the strings from resources.
Moved the **InjectWindowsThemes** code into the larger code block.

✔️ Somebody check if this is correct:

```cs
 if (file.Contains(Helper.PathUnmanagedDarkTheme) ||
    file.Contains(Helper.PathUnmanagedLightTheme) ||
    file.Contains(Helper.PathManagedTheme)) continue;
```

Because a different part ~uses~ used "NameUnmanagedLightTheme"

```cs
 .Where(f => !f.Contains(Helper.PathUnmanagedDarkTheme) && !f.Contains(Helper.NameUnmanagedLightTheme) && !f.Contains(Helper.PathManagedTheme)).ToList();
```

~❓ Question: should we (alphabetically) sort the final list?~ done

> [!NOTE]
> I don't use Windows 10 anymore, so would be great if somebody could test that! 

### Screenshot? Sure!

![Theme switching](https://github.com/user-attachments/assets/a5934b53-a043-48c8-8eea-c5ee22ba54c3)
