### PR TITLE
Add PowerToys Light Switch conflict warning

### DIFF
--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -665,6 +665,12 @@ Currently installed version: {0}, new version: {1}</value>
   <data name="PostponeTime_SkipOnce" xml:space="preserve">
     <value>Skip auto switch once</value>
   </data>
+  <data name="PowerToysConflict_Content" xml:space="preserve">
+    <value>PowerToys Light Switch is active and may conflict with Auto Dark Mode. Disable it in PowerToys settings to avoid unexpected theme switching.</value>
+  </data>
+  <data name="PowerToysConflict_Title" xml:space="preserve">
+    <value>PowerToys Light Switch detected</value>
+  </data>
   <data name="ProcessBlockList" xml:space="preserve">
     <value>Don't switch while certain apps are running</value>
   </data>

--- a/AutoDarkModeApp/ViewModels/SettingsViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/SettingsViewModel.cs
@@ -66,6 +66,9 @@ public partial class SettingsViewModel : ObservableRecipient
     public partial bool IsLanguageChangedInfoBarOpen { get; set; }
 
     [ObservableProperty]
+    public partial bool IsPowerToysConflictBarOpen { get; set; }
+
+    [ObservableProperty]
     public partial DaysBetweenUpdateCheck SelectedDaysBetweenUpdateCheck { get; set; }
 
     [ObservableProperty]
@@ -136,6 +139,7 @@ public partial class SettingsViewModel : ObservableRecipient
         );
 
         LoadSettings();
+        IsPowerToysConflictBarOpen = Process.GetProcessesByName("PowerToys.LightSwitchService").Length > 0;
         _dispatcherQueue.TryEnqueue(async () => await GetAutostartInfo());
         SetAutostartDetailsVisibility(true);
 

--- a/AutoDarkModeApp/Views/SettingsPage.xaml
+++ b/AutoDarkModeApp/Views/SettingsPage.xaml
@@ -19,6 +19,14 @@
         <Grid x:Name="ContentArea">
             <StackPanel Style="{StaticResource PageBaseStackPanelStyle}">
 
+                <!--  Compatibility warnings  -->
+                <InfoBar
+                    IsClosable="False"
+                    IsOpen="{x:Bind ViewModel.IsPowerToysConflictBarOpen, Mode=OneWay}"
+                    Message="{helpers:ResourceString Name=PowerToysConflict_Content}"
+                    Severity="Warning"
+                    Title="{helpers:ResourceString Name=PowerToysConflict_Title}" />
+
                 <!--  Some settings  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=Settings}" />
                 <controls:SettingsCard ContentAlignment="Left">


### PR DESCRIPTION
## Summary

Detects whether PowerToys Light Switch (`PowerToys.LightSwitchService`) is running when the Settings page is loaded, and shows a warning `InfoBar` if a conflict is found.

Closes #1120

## Changes

- **`SettingsViewModel.cs`**: Added `IsPowerToysConflictBarOpen` observable property, detected via `Process.GetProcessesByName("PowerToys.LightSwitchService").Length > 0` in the constructor
- **`SettingsPage.xaml`**: Added a `Severity="Warning"` `InfoBar` at the top of the page, bound to `IsPowerToysConflictBarOpen`
- **`Strings/en-us/Resources.resw`**: Added `PowerToysConflict_Title` and `PowerToysConflict_Content` localization keys