### PR TITLE
Fix: Disable duplicate shortcut keys

### DIFF
--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -370,6 +370,12 @@ Would you like to create an issue on the Auto Dark Mode repository?</value>
   <data name="Hotkeys" xml:space="preserve">
     <value>Hotkeys</value>
   </data>
+  <data name="HotkeyDuplicateErrorTitle" xml:space="preserve">
+    <value>Duplicate Hotkey</value>
+  </data>
+  <data name="HotkeyDuplicateErrorMessage" xml:space="preserve">
+    <value>This hotkey is already used by "{0}". Please choose a different key combination.</value>
+  </data>
   <data name="IdleTime" xml:space="preserve">
     <value>Time in minutes before the system is considered idle</value>
   </data>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -376,6 +376,9 @@ Would you like to create an issue on the Auto Dark Mode repository?</value>
   <data name="HotkeyDuplicateErrorMessage" xml:space="preserve">
     <value>This hotkey is already used by "{0}". Please choose a different key combination.</value>
   </data>
+  <data name="HotkeyInvalidErrorMessage" xml:space="preserve">
+    <value>Invalid hotkey combination. Please include at least one non-modifier key (e.g., a letter, number, or function key).</value>
+  </data>
   <data name="IdleTime" xml:space="preserve">
     <value>Time in minutes before the system is considered idle</value>
   </data>

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml
@@ -10,6 +10,13 @@
 
     <StackPanel Orientation="Vertical" Spacing="16">
 
+        <InfoBar
+            x:Name="ErrorInfoBar"
+            IsClosable="False"
+            IsOpen="{x:Bind IsErrorVisible, Mode=OneWay}"
+            Message="{x:Bind ErrorMessage, Mode=OneWay}"
+            Severity="Error" />
+
         <TextBlock Text="{helpers:ResourceString Name=SelectTheKeyCombination}" TextWrapping="Wrap" />
 
         <ItemsControl

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -11,8 +11,26 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     [GeneratedDependencyProperty]
     public partial string? CapturedHotkeys { get; set; }
 
+    [GeneratedDependencyProperty]
+    public partial bool IsErrorVisible { get; set; }
+
+    [GeneratedDependencyProperty]
+    public partial string? ErrorMessage { get; set; }
+
     private KeyboardHook? _keyboardHook;
     private bool _isCapturing;
+
+    public void ShowError(string message)
+    {
+        ErrorMessage = message;
+        IsErrorVisible = true;
+    }
+
+    public void HideError()
+    {
+        IsErrorVisible = false;
+        ErrorMessage = null;
+    }
 
     public void LoadFromKeyValue(string? hotkeyValue)
     {
@@ -101,6 +119,8 @@ public sealed partial class ShortcutDialogContentControl : UserControl
         {
             CapturedHotkeys = string.Join(" + ", displayParts);
             HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
+
+            HideError();
         });
 
         e.Handled = true;

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -17,6 +17,8 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     [GeneratedDependencyProperty]
     public partial string? ErrorMessage { get; set; }
 
+    public Func<string?, (bool isDuplicate, string? conflictingName)>? ValidateHotkey { get; set; }
+
     private KeyboardHook? _keyboardHook;
     private bool _isCapturing;
 
@@ -104,10 +106,14 @@ public sealed partial class ShortcutDialogContentControl : UserControl
         }
 
         List<string> displayParts = [];
-        if (isCtrl) displayParts.Add("Ctrl");
-        if (isShift) displayParts.Add("Shift");
-        if (isAlt) displayParts.Add("Alt");
-        if (isWin) displayParts.Add("Win");
+        if (isCtrl)
+            displayParts.Add("Ctrl");
+        if (isShift)
+            displayParts.Add("Shift");
+        if (isAlt)
+            displayParts.Add("Alt");
+        if (isWin)
+            displayParts.Add("Win");
 
         var key = (VirtualKey)e.VirtualKeyCode;
         if (!IsModifierKey(key))
@@ -120,7 +126,22 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             CapturedHotkeys = string.Join(" + ", displayParts);
             HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
 
-            HideError();
+            if (ValidateHotkey is not null)
+            {
+                var (isDuplicate, conflictingName) = ValidateHotkey(CapturedHotkeys);
+                if (isDuplicate)
+                {
+                    ShowError(string.Format(ResourceExtensions.GetLocalized("HotkeyDuplicateErrorMessage"), conflictingName));
+                }
+                else
+                {
+                    HideError();
+                }
+            }
+            else
+            {
+                HideError();
+            }
         });
 
         e.Handled = true;

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -12,6 +12,9 @@ public sealed partial class ShortcutDialogContentControl : UserControl
     public partial string? CapturedHotkeys { get; set; }
 
     [GeneratedDependencyProperty]
+    public partial bool HasNonModifierKey { get; set; }
+
+    [GeneratedDependencyProperty]
     public partial bool IsErrorVisible { get; set; }
 
     [GeneratedDependencyProperty]
@@ -116,9 +119,9 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             displayParts.Add("Win");
 
         var key = (VirtualKey)e.VirtualKeyCode;
-        var hasNonModifierKey = !IsModifierKey(key);
+        HasNonModifierKey = !IsModifierKey(key);
 
-        if (hasNonModifierKey)
+        if (HasNonModifierKey)
         {
             displayParts.Add(HotkeyStringConverter.GetKeyDisplayName(key));
         }
@@ -128,19 +131,12 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             CapturedHotkeys = string.Join(" + ", displayParts);
             HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
 
-            if (hasNonModifierKey)
+            if (ValidateHotkey is not null)
             {
-                if (ValidateHotkey is not null)
+                var (isDuplicate, conflictingName) = ValidateHotkey(CapturedHotkeys);
+                if (isDuplicate)
                 {
-                    var (isDuplicate, conflictingName) = ValidateHotkey(CapturedHotkeys);
-                    if (isDuplicate)
-                    {
-                        ShowError(string.Format(ResourceExtensions.GetLocalized("HotkeyDuplicateErrorMessage"), conflictingName));
-                    }
-                    else
-                    {
-                        HideError();
-                    }
+                    ShowError(string.Format(ResourceExtensions.GetLocalized("HotkeyDuplicateErrorMessage"), conflictingName));
                 }
                 else
                 {
@@ -149,7 +145,7 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             }
             else
             {
-                ShowError(ResourceExtensions.GetLocalized("HotkeyInvalidErrorMessage"));
+                HideError();
             }
         });
 

--- a/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
+++ b/AutoDarkModeApp/UserControls/ShortcutDialogContentControl.xaml.cs
@@ -116,7 +116,9 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             displayParts.Add("Win");
 
         var key = (VirtualKey)e.VirtualKeyCode;
-        if (!IsModifierKey(key))
+        var hasNonModifierKey = !IsModifierKey(key);
+
+        if (hasNonModifierKey)
         {
             displayParts.Add(HotkeyStringConverter.GetKeyDisplayName(key));
         }
@@ -126,12 +128,19 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             CapturedHotkeys = string.Join(" + ", displayParts);
             HotkeyCombination = displayParts.Select(p => new SingleHotkeyDataObject { Key = p }).ToList();
 
-            if (ValidateHotkey is not null)
+            if (hasNonModifierKey)
             {
-                var (isDuplicate, conflictingName) = ValidateHotkey(CapturedHotkeys);
-                if (isDuplicate)
+                if (ValidateHotkey is not null)
                 {
-                    ShowError(string.Format(ResourceExtensions.GetLocalized("HotkeyDuplicateErrorMessage"), conflictingName));
+                    var (isDuplicate, conflictingName) = ValidateHotkey(CapturedHotkeys);
+                    if (isDuplicate)
+                    {
+                        ShowError(string.Format(ResourceExtensions.GetLocalized("HotkeyDuplicateErrorMessage"), conflictingName));
+                    }
+                    else
+                    {
+                        HideError();
+                    }
                 }
                 else
                 {
@@ -140,7 +149,7 @@ public sealed partial class ShortcutDialogContentControl : UserControl
             }
             else
             {
-                HideError();
+                ShowError(ResourceExtensions.GetLocalized("HotkeyInvalidErrorMessage"));
             }
         });
 

--- a/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/HotkeysViewModel.cs
@@ -102,6 +102,47 @@ public partial class HotkeysViewModel : ObservableRecipient
         SafeSaveBuilder();
     }
 
+    public (bool isDuplicate, string? conflictingName) IsDuplicateHotkey(string currentTag, string? newKeys)
+    {
+        if (string.IsNullOrWhiteSpace(newKeys))
+        {
+            return (false, null);
+        }
+
+        var normalizedNewKeys = newKeys.Trim();
+
+        var allHotkeys = new[]
+        {
+            (Tag: "ForceLight", Keys: _builder.Config.Hotkeys.ForceLight, Name: "ForceLight"),
+            (Tag: "ForceDark", Keys: _builder.Config.Hotkeys.ForceDark, Name: "ForceDark"),
+            (Tag: "StopForcing", Keys: _builder.Config.Hotkeys.NoForce, Name: "StopForcing"),
+            (Tag: "ToggleTheme", Keys: _builder.Config.Hotkeys.ToggleTheme, Name: "ToggleTheme"),
+            (Tag: "AutomaticThemeSwitch", Keys: _builder.Config.Hotkeys.ToggleAutoThemeSwitch, Name: "AutomaticThemeSwitch"),
+            (Tag: "PauseAutoThemeSwitching", Keys: _builder.Config.Hotkeys.TogglePostpone, Name: "PauseAutoThemeSwitching"),
+        };
+
+        foreach (var hotkey in allHotkeys)
+        {
+            if (hotkey.Tag == currentTag)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(hotkey.Keys))
+            {
+                continue;
+            }
+
+            if (hotkey.Keys.Trim().Equals(normalizedNewKeys, StringComparison.OrdinalIgnoreCase))
+            {
+                var displayName = HotkeysCollection?.FirstOrDefault(h => h.Tag == hotkey.Tag)?.DisplayName ?? hotkey.Name;
+                return (true, displayName);
+            }
+        }
+
+        return (false, null);
+    }
+
     public HotkeysViewModel(IErrorService errorService)
     {
         _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -42,18 +42,30 @@ public sealed partial class HotkeysPage : Page
             Content = dialogContent,
         };
 
+        shortcutDialog.Closing += (dialog, args) =>
+        {
+            if (args.Result == ContentDialogResult.Primary)
+            {
+                var (isDuplicate, conflictingName) = ViewModel.IsDuplicateHotkey(hotkeyData.Tag, dialogContent.CapturedHotkeys);
+                if (isDuplicate)
+                {
+                    dialogContent.ShowError(string.Format("HotkeyDuplicateErrorMessage".GetLocalized(), conflictingName));
+                    args.Cancel = true;
+                }
+            }
+        };
+
         var result = await shortcutDialog.ShowAsync();
         if (result == ContentDialogResult.Secondary)
         {
             dialogContent.HotkeyCombination?.Clear();
             dialogContent.CapturedHotkeys = null;
         }
-        else if (result != ContentDialogResult.Primary)
-        {
-            return;
-        }
 
-        ViewModel.UpdateHotkeyValue(hotkeyData.Tag, dialogContent.CapturedHotkeys);
+        if (result == ContentDialogResult.Primary || result == ContentDialogResult.Secondary)
+        {
+            ViewModel.UpdateHotkeyValue(hotkeyData.Tag, dialogContent.CapturedHotkeys);
+        }
     }
 
     private async void SaveSettingsButton_Click(object sender, RoutedEventArgs e)

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class HotkeysPage : Page
 
         var keyValue = ViewModel.GetHotkeyValue(hotkeyData.Tag);
         var dialogContent = new ShortcutDialogContentControl();
+        dialogContent.ValidateHotkey = (newKeys) => ViewModel.IsDuplicateHotkey(hotkeyData.Tag, newKeys);
 
         if (keyValue is not null)
         {
@@ -46,10 +47,8 @@ public sealed partial class HotkeysPage : Page
         {
             if (args.Result == ContentDialogResult.Primary)
             {
-                var (isDuplicate, conflictingName) = ViewModel.IsDuplicateHotkey(hotkeyData.Tag, dialogContent.CapturedHotkeys);
-                if (isDuplicate)
+                if (dialogContent.IsErrorVisible)
                 {
-                    dialogContent.ShowError(string.Format("HotkeyDuplicateErrorMessage".GetLocalized(), conflictingName));
                     args.Cancel = true;
                 }
             }

--- a/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
+++ b/AutoDarkModeApp/Views/HotkeysPage.xaml.cs
@@ -47,6 +47,10 @@ public sealed partial class HotkeysPage : Page
         {
             if (args.Result == ContentDialogResult.Primary)
             {
+                if (!dialogContent.HasNonModifierKey)
+                {
+                    dialogContent.ShowError("HotkeyInvalidErrorMessage".GetLocalized());
+                }
                 if (dialogContent.IsErrorVisible)
                 {
                     args.Cancel = true;


### PR DESCRIPTION
### Description

Before, we allowed multiple shortcuts to use the same shortcut key. This PR improves this problem. Now when you try to save the same shortcut key, an error message will pop up and you can't save it.

Sloved #1146.

### Screenshots

<img width="1140" height="896" alt="image" src="https://github.com/user-attachments/assets/ce10975a-d004-4624-a48f-7a86ebd303f7" />
