### PR TITLE
Enable dependabot (simple config)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: weekly
 
-  # AutoDarkModeApp
   - package-ecosystem: nuget
     directories:
       - "/AutoDarkMode*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # AutoDarkModeApp
+  - package-ecosystem: nuget
+    directories:
+      - "/AutoDarkMode*"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Config docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

This is a simplified version of https://github.com/AutoDarkMode/Windows-Auto-Night-Mode/pull/783.
I hope it helps to get this merged sooner, 783 could then be a more sophisticated version on top (if needed).