### PR TITLE
Feature: Support energy saving mode switch theme

### DIFF
--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -1125,4 +1125,7 @@ Please note: This may introduce slight to moderate lag on some systems during th
   <data name="Contributors" xml:space="preserve">
     <value>Contributors</value>
   </data>
+  <data name="FollowEnergySavingMode" xml:space="preserve">
+    <value>Follow energy saving mode</value>
+  </data>
 </root>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -1126,6 +1126,9 @@ Please note: This may introduce slight to moderate lag on some systems during th
     <value>Contributors</value>
   </data>
   <data name="FollowEnergySavingMode" xml:space="preserve">
-    <value>Follow energy saving mode</value>
+    <value>Follow Energy Saver mode</value>
+  </data>
+    <data name="OpenWindowsPowerSleep" xml:space="preserve">
+    <value>Go to Power sleep settings</value>
   </data>
 </root>

--- a/AutoDarkModeApp/ViewModels/TimeViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/TimeViewModel.cs
@@ -20,6 +20,7 @@ public partial class TimeViewModel : ObservableRecipient
         CoordinateTimes,
         WindowsNightLight,
         AmbientLight,
+        PowerLight
     }
 
     [ObservableProperty]
@@ -552,6 +553,16 @@ public partial class TimeViewModel : ObservableRecipient
             return;
         }
 
+        if(_builder.Config.Governor == Governor.Power)
+        {
+            SelectedTriggerMode = SwitchTriggerMode.PowerLight;
+            TimePickerVisibility = Visibility.Collapsed;
+            DividerBorderVisibility = Visibility.Collapsed;
+            OffsetTimeSettingsCardVisibility = Visibility.Collapsed;
+            PostponeOptionsSkipOnceVisibility = Visibility.Collapsed;
+            return;
+        }
+
         if (!_builder.Config.Location.Enabled)
         {
             SelectedTriggerMode = SwitchTriggerMode.CustomTimes;
@@ -724,6 +735,16 @@ public partial class TimeViewModel : ObservableRecipient
                     AutoConfigure();
                 }
                 _builder.Config.Governor = Governor.AmbientLight;
+                _builder.Config.AutoThemeSwitchingEnabled = true;
+                _builder.Config.Location.Enabled = false;
+                _builder.Config.Location.UseGeolocatorService = false;
+                TimePickerVisibility = Visibility.Collapsed;
+                DividerBorderVisibility = Visibility.Collapsed;
+                OffsetTimeSettingsCardVisibility = Visibility.Collapsed;
+                break;
+
+            case SwitchTriggerMode.PowerLight:
+                _builder.Config.Governor = Governor.Power;
                 _builder.Config.AutoThemeSwitchingEnabled = true;
                 _builder.Config.Location.Enabled = false;
                 _builder.Config.Location.UseGeolocatorService = false;

--- a/AutoDarkModeApp/ViewModels/TimeViewModel.cs
+++ b/AutoDarkModeApp/ViewModels/TimeViewModel.cs
@@ -20,7 +20,7 @@ public partial class TimeViewModel : ObservableRecipient
         CoordinateTimes,
         WindowsNightLight,
         AmbientLight,
-        PowerLight
+        EnergySaver
     }
 
     [ObservableProperty]
@@ -555,7 +555,7 @@ public partial class TimeViewModel : ObservableRecipient
 
         if(_builder.Config.Governor == Governor.Power)
         {
-            SelectedTriggerMode = SwitchTriggerMode.PowerLight;
+            SelectedTriggerMode = SwitchTriggerMode.EnergySaver;
             TimePickerVisibility = Visibility.Collapsed;
             DividerBorderVisibility = Visibility.Collapsed;
             OffsetTimeSettingsCardVisibility = Visibility.Collapsed;
@@ -743,7 +743,7 @@ public partial class TimeViewModel : ObservableRecipient
                 OffsetTimeSettingsCardVisibility = Visibility.Collapsed;
                 break;
 
-            case SwitchTriggerMode.PowerLight:
+            case SwitchTriggerMode.EnergySaver:
                 _builder.Config.Governor = Governor.Power;
                 _builder.Config.AutoThemeSwitchingEnabled = true;
                 _builder.Config.Location.Enabled = false;

--- a/AutoDarkModeApp/Views/TimePage.xaml
+++ b/AutoDarkModeApp/Views/TimePage.xaml
@@ -87,10 +87,10 @@
                                 </StackPanel>
                                 <RadioButton
                                     Command="{x:Bind ViewModel.SetTriggerModeCommand}"
-                                    CommandParameter="PowerLight"
+                                    CommandParameter="EnergySaver"
                                     Content="{helpers:ResourceString Name=FollowEnergySavingMode}"
                                     GroupName="TriggerMode"
-                                    IsChecked="{x:Bind ViewModel.SelectedTriggerMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=PowerLight, Mode=OneWay}" />
+                                    IsChecked="{x:Bind ViewModel.SelectedTriggerMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=EnergySaver, Mode=OneWay}" />
                             </StackPanel>
 
                             <Border Style="{StaticResource DividerBorderStyle}" />
@@ -247,6 +247,12 @@
                                 Click="WindowsNightLightHyperlinkButton_Click"
                                 Content="{helpers:ResourceString Name=OpenWindowsNightLight}"
                                 Visibility="{x:Bind ViewModel.SelectedTriggerMode, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter=WindowsNightLight, Mode=OneWay}" />
+
+                            <!--  Energy Saver  -->
+                            <HyperlinkButton
+                                Click="WindowsPowerSleepHyperlinkButton_Click"
+                                Content="{helpers:ResourceString Name=OpenWindowsPowerSleep}"
+                                Visibility="{x:Bind ViewModel.SelectedTriggerMode, Converter={StaticResource EnumToVisibilityConverter}, ConverterParameter=EnergySaver, Mode=OneWay}" />
 
                             <!--  Ambient Light Sensor  -->
                             <StackPanel

--- a/AutoDarkModeApp/Views/TimePage.xaml
+++ b/AutoDarkModeApp/Views/TimePage.xaml
@@ -85,6 +85,12 @@
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         Glyph="&#xE946;" />
                                 </StackPanel>
+                                <RadioButton
+                                    Command="{x:Bind ViewModel.SetTriggerModeCommand}"
+                                    CommandParameter="PowerLight"
+                                    Content="{helpers:ResourceString Name=FollowEnergySavingMode}"
+                                    GroupName="TriggerMode"
+                                    IsChecked="{x:Bind ViewModel.SelectedTriggerMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=PowerLight, Mode=OneWay}" />
                             </StackPanel>
 
                             <Border Style="{StaticResource DividerBorderStyle}" />

--- a/AutoDarkModeApp/Views/TimePage.xaml.cs
+++ b/AutoDarkModeApp/Views/TimePage.xaml.cs
@@ -106,6 +106,11 @@ public sealed partial class TimePage : Page
         await Windows.System.Launcher.LaunchUriAsync(new Uri("ms-settings:nightlight"));
     }
 
+    private async void WindowsPowerSleepHyperlinkButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        await Windows.System.Launcher.LaunchUriAsync(new Uri("ms-settings:powersleep"));
+    }
+
     private void AmbientLightRangeSelector_Loaded(object sender, RoutedEventArgs e)
     {
         try

--- a/AutoDarkModeLib/Enums.cs
+++ b/AutoDarkModeLib/Enums.cs
@@ -57,6 +57,7 @@ public enum SwitchSource
     TimeSwitchModule,
     NightLightTrackerModule,
     AmbientLightSensorModule,
+    PowerModule,
     BatteryStatusChanged,
     SystemResume,
     Manual,
@@ -81,6 +82,7 @@ public enum ThemeOverrideSource
     TimedThemeState,
     NightLight,
     AmbientLight,
+    Power,
     ForceFlag,
     BatteryStatus,
     PostponeManager
@@ -90,7 +92,8 @@ public enum Governor
 {
     Default,
     NightLight,
-    AmbientLight
+    AmbientLight,
+    Power
 }
 
 public enum SkipType

--- a/AutoDarkModeSvc/Core/GlobalState.cs
+++ b/AutoDarkModeSvc/Core/GlobalState.cs
@@ -70,6 +70,7 @@ public class GlobalState
     public PostponeManager PostponeManager { get; }
     public NightLight NightLight { get; } = new();
     public AmbientLightState AmbientLight { get; } = new();
+    public PowerState PowerState { get; } = new();
     public SystemIdleModuleState SystemIdleModuleState { get; } = new();
     public bool InitSyncSwitchPerformed { get; set; } = false;
     private NotifyIcon NotifyIcon { get; set; }
@@ -257,6 +258,12 @@ public class AmbientLightState
     /// Callback to trigger re-evaluation of lux against current thresholds
     /// </summary>
     public Action ReEvaluateCallback { get; set; } = () => { };
+}
+
+public class  PowerState
+{
+    public Theme Requested { get; set; } = Theme.Unknown;
+    public int EnergySaver { get; set; } = 0;
 }
 
 public class SystemIdleModuleState

--- a/AutoDarkModeSvc/Core/ThemeManager.cs
+++ b/AutoDarkModeSvc/Core/ThemeManager.cs
@@ -122,6 +122,11 @@ static class ThemeManager
                 e.OverrideTheme(state.AmbientLight.Requested, ThemeOverrideSource.AmbientLight);
                 UpdateTheme(e);
             }
+            else if (builder.Config.Governor == Governor.Power)
+            {
+                e.OverrideTheme(state.PowerState.Requested, ThemeOverrideSource.Power);
+                UpdateTheme(e);
+            }
         }
         else
         {

--- a/AutoDarkModeSvc/Governors/PowerGovernor.cs
+++ b/AutoDarkModeSvc/Governors/PowerGovernor.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoDarkModeLib;
+using AutoDarkModeSvc.Core;
+using AutoDarkModeSvc.Events;
+using AutoDarkModeSvc.Handlers;
+using AutoDarkModeSvc.Interfaces;
+using AutoDarkModeSvc.Modules;
+using Microsoft.Win32;
+
+namespace AutoDarkModeSvc.Governors;
+
+public class PowerGovernor : IAutoDarkModeGovernor
+{
+    public Governor Type => Governor.Power;
+    private IAutoDarkModeModule Master { get; }
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+    private GlobalState state = GlobalState.Instance();
+    private bool init = true;
+
+    private AdmConfigBuilder builder = AdmConfigBuilder.Instance();
+    private readonly object powerWatcherLock = new();
+    private CancellationTokenSource powerWatcherCancellation;
+    private Task powerWatcherTask;
+
+    private const uint RegNotifyChangeLastSet = 0x00000004;
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern int RegNotifyChangeKeyValue(IntPtr hKey, bool watchSubtree, uint notifyFilter, IntPtr hEvent, bool asynchronous);
+
+    public PowerGovernor(IAutoDarkModeModule master)
+    {
+        Master = master;
+    }
+
+    public GovernorEventArgs Run()
+    {
+        // Reload config to pick up any changes made directly to the config file
+        builder.Load();
+
+        if (init)
+        {
+            init = false;
+        }
+
+        return new(false, new(SwitchSource.PowerModule, state.PowerState.Requested));
+    }
+
+    private void UpdatePowerState()
+    {
+        try
+        {
+            var energySaverEnabled = RegistryHandler.IsEnergySaverEnabled();
+            if (energySaverEnabled)
+            {
+                state.PowerState.Requested = Theme.Dark;
+            }
+            else
+            {
+                state.PowerState.Requested = Theme.Light;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error updating power state");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.Synchronized)]
+    private void MonitorPowerRegistry(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using RegistryKey powerKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Power");
+            if (powerKey is null)
+            {
+                Logger.Error("Could not open the power registry key for native change notifications.");
+                return;
+            }
+
+            using AutoResetEvent registryChanged = new(false);
+            WaitHandle[] waitHandles = [registryChanged, cancellationToken.WaitHandle];
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                int result = RegNotifyChangeKeyValue(
+                    powerKey.Handle.DangerousGetHandle(),
+                    false,
+                    RegNotifyChangeLastSet,
+                    registryChanged.SafeWaitHandle.DangerousGetHandle(),
+                    true);
+
+                if (result != 0)
+                {
+                    Logger.Error("Failed to register the native power registry notification. Error code: {ErrorCode}", result);
+                    return;
+                }
+
+                if (WaitHandle.WaitAny(waitHandles) == 0)
+                {
+                    UpdatePowerState();
+                    Master.Fire(this);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Power governor native registry monitor stopped unexpectedly.");
+        }
+    }
+
+    public void EnableHook()
+    {
+        lock (powerWatcherLock)
+        {
+            if (powerWatcherTask == null)
+            {
+                powerWatcherCancellation = new CancellationTokenSource();
+                powerWatcherTask = Task.Run(() => MonitorPowerRegistry(powerWatcherCancellation.Token));
+                Logger.Info("Power governor native registry monitor enabled.");
+            }
+        }
+
+        UpdatePowerState();
+    }
+
+    public void DisableHook()
+    {
+        CancellationTokenSource cancellation;
+        Task watcherTask;
+
+        lock (powerWatcherLock)
+        {
+            cancellation = powerWatcherCancellation;
+            watcherTask = powerWatcherTask;
+            powerWatcherCancellation = null;
+            powerWatcherTask = null;
+        }
+
+        try
+        {
+            cancellation?.Cancel();
+            watcherTask?.Wait();
+            Logger.Info("Power governor native registry monitor disabled.");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to disable power governor hook.");
+        }
+        finally
+        {
+            cancellation?.Dispose();
+        }
+    }
+}

--- a/AutoDarkModeSvc/Handlers/RegistryHandler.cs
+++ b/AutoDarkModeSvc/Handlers/RegistryHandler.cs
@@ -146,6 +146,15 @@ static class RegistryHandler
         return byteData.Length > 24 && byteData[23] == decimal.ToByte(0x10) && byteData[24] == decimal.ToByte(0x00);
     }
 
+    public static bool IsEnergySaverEnabled()
+    {
+        using RegistryKey key = GetPowerKey();
+        var enabled = key.GetValue("EnergySaverState").Equals(1);
+        if (enabled)
+            return true;
+        return false;
+    }
+
     public static string GetActiveThemePath()
     {
         // call first becaues it refreshes the regkey
@@ -278,6 +287,12 @@ static class RegistryHandler
     private static RegistryKey GetNightLightKey()
     {
         RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\CloudStore\Store\DefaultAccount\Current\default$windows.data.bluelightreduction.bluelightreductionstate\windows.data.bluelightreduction.bluelightreductionstate");
+        return key;
+    }
+
+    private static RegistryKey GetPowerKey()
+    {
+        RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Control\Power");
         return key;
     }
 

--- a/AutoDarkModeSvc/Modules/GovernorModule.cs
+++ b/AutoDarkModeSvc/Modules/GovernorModule.cs
@@ -105,6 +105,10 @@ internal class GovernorModule : AutoDarkModeModule
             {
                 ActiveGovernor = new AmbientLightGovernor(this);
             }
+            else if (newGovernor == Governor.Power)
+            {
+                ActiveGovernor = new PowerGovernor(this);
+            }
             ActiveGovernor.EnableHook();
         }
     }


### PR DESCRIPTION
### Description

- Done one of #15

When the computer's power-saving mode is turned on, the theme switches to dark mode; when power-saving mode is turned off, it switches back to light mode.

### Supplement

The reason for not using the WinRT API is that, following the [Windows 11 24H2 update](https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/energy-saver), the new power-saving mode features have been expanded, while `PowerManager.EnergySaverStatus` still uses the old battery power-saving mode. For more details, please refer to this [link](https://learn.microsoft.com/en-us/answers/questions/5579583/powermanager-energysaverstatus-not-working-properl). Testing has shown that when the device is plugged in, this value is always set to “Disabled.” The Win32 API behaves the same way. The registry solution, however, offers greater versatility, which is the compatibility that ADM has always sought.

### Screenshots

<img width="1328" height="859" alt="image" src="https://github.com/user-attachments/assets/1e9653e0-fe7b-47f2-b42e-43b9648ad171" />


<img width="1332" height="868" alt="PixPin_2026-07-18_16-10-14" src="https://github.com/user-attachments/assets/2ac1d13a-c5f8-4b59-9f4b-7e74dffe84c4" />
