### PR TITLE
Add version info to About page

### DIFF
--- a/AutoDarkModeApp/Models/GitHubRelease.cs
+++ b/AutoDarkModeApp/Models/GitHubRelease.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoDarkModeApp.Models;
+
+public sealed class GitHubRelease
+{
+    public string TagName { get; set; }
+    public string Name { get; set; }
+    public DateTime PublishedAt { get; set; }
+    public bool IsPrerelease { get; set; }
+    public string HtmlUrl { get; set; }
+}

--- a/AutoDarkModeApp/Services/GitHubReleaseService.cs
+++ b/AutoDarkModeApp/Services/GitHubReleaseService.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoDarkModeApp.Services;
+
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text.Json;
+
+public sealed class GitHubReleaseService : IGitHubReleaseService
+{
+    private readonly HttpClient _client = new();
+
+    public GitHubReleaseService()
+    {
+        _client.DefaultRequestHeaders.UserAgent.ParseAdd("AutoDarkMode-App");
+        _client.Timeout = TimeSpan.FromSeconds(10); // set a timeout for the request
+    }
+
+    public async Task<List<GitHubRelease>> FetchReleasesAsync()
+    {
+        try
+        {
+
+        var url = "https://api.github.com/repos/AutoDarkMode/Windows-Auto-Night-Mode/releases";
+        var json = await _client.GetStringAsync(url);
+
+        using var doc = JsonDocument.Parse(json);
+        var releases = new List<GitHubRelease>();
+
+        foreach (var r in doc.RootElement.EnumerateArray())
+        {
+            releases.Add(new GitHubRelease
+            {
+                TagName = r.GetProperty("tag_name").GetString(),
+                Name = r.GetProperty("name").GetString(),
+                PublishedAt = r.GetProperty("published_at").GetDateTime(),
+                IsPrerelease = r.GetProperty("prerelease").GetBoolean(),
+                HtmlUrl = r.GetProperty("html_url").GetString()
+            });
+        }
+
+        return releases;
+        }
+        catch (HttpRequestException ex)
+        {
+            // GitHub offline, DNS error, SSL error, 404, 403, 500, etc.
+            Debug.WriteLine($"GitHub request failed: {ex.Message}");
+            return new List<GitHubRelease>(); // veilige fallback
+        }
+        catch (TaskCanceledException ex)
+        {
+            // timeout
+            Debug.WriteLine($"GitHub request timed out: {ex.Message}");
+            return new List<GitHubRelease>();
+        }
+        catch (Exception ex)
+        {
+            // onverwachte fout
+            Debug.WriteLine($"Unexpected error fetching releases: {ex.Message}");
+            return new List<GitHubRelease>();
+        }
+    }
+
+    public async Task<GitHubRelease?> GetReleaseForVersionAsync(string version)
+    {
+        var releases = await FetchReleasesAsync();
+
+        var exact = releases.FirstOrDefault(r => r.TagName == version);
+        if (exact != null)
+        {
+            return exact;
+        }
+
+        var latest = releases
+            .Where(r => !r.IsPrerelease)
+            .OrderByDescending(r => r.PublishedAt)
+            .FirstOrDefault();
+        return latest;
+    }
+}

--- a/AutoDarkModeApp/Services/IGitHubReleaseService.cs
+++ b/AutoDarkModeApp/Services/IGitHubReleaseService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AutoDarkModeApp.Services;
+
+public interface IGitHubReleaseService
+{
+    Task<List<GitHubRelease>> FetchReleasesAsync();
+    Task<GitHubRelease?> GetReleaseForVersionAsync(string version);
+}

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -1132,4 +1132,7 @@ Please note: This may introduce slight to moderate lag on some systems during th
   <data name="LatestRelease" xml:space="preserve">
     <value>Latest official release</value>
   </data>
+  <data name="ReleaseInfoUnavailable" xml:space="preserve">
+    <value>Release information unavailable</value>
+  </data>
 </root>

--- a/AutoDarkModeApp/Strings/en-us/Resources.resw
+++ b/AutoDarkModeApp/Strings/en-us/Resources.resw
@@ -370,15 +370,6 @@ Would you like to create an issue on the Auto Dark Mode repository?</value>
   <data name="Hotkeys" xml:space="preserve">
     <value>Hotkeys</value>
   </data>
-  <data name="HotkeyDuplicateErrorTitle" xml:space="preserve">
-    <value>Duplicate Hotkey</value>
-  </data>
-  <data name="HotkeyDuplicateErrorMessage" xml:space="preserve">
-    <value>This hotkey is already used by "{0}". Please choose a different key combination.</value>
-  </data>
-  <data name="HotkeyInvalidErrorMessage" xml:space="preserve">
-    <value>Invalid hotkey combination. Please include at least one non-modifier key (e.g., a letter, number, or function key).</value>
-  </data>
   <data name="IdleTime" xml:space="preserve">
     <value>Time in minutes before the system is considered idle</value>
   </data>
@@ -670,12 +661,6 @@ Currently installed version: {0}, new version: {1}</value>
   </data>
   <data name="PostponeTime_SkipOnce" xml:space="preserve">
     <value>Skip auto switch once</value>
-  </data>
-  <data name="PowerToysConflict_Content" xml:space="preserve">
-    <value>PowerToys Light Switch is active and may conflict with Auto Dark Mode. Disable it in PowerToys settings to avoid unexpected theme switching.</value>
-  </data>
-  <data name="PowerToysConflict_Title" xml:space="preserve">
-    <value>PowerToys Light Switch detected</value>
   </data>
   <data name="ProcessBlockList" xml:space="preserve">
     <value>Don't switch while certain apps are running</value>
@@ -1044,6 +1029,21 @@ Please note: This may introduce slight to moderate lag on some systems during th
   <data name="ShowTrayIcon" xml:space="preserve">
     <value>Show tray icon (recommended)</value>
   </data>
+  <data name="HotkeyDuplicateErrorTitle" xml:space="preserve">
+    <value>Duplicate Hotkey</value>
+  </data>
+  <data name="HotkeyDuplicateErrorMessage" xml:space="preserve">
+    <value>This hotkey is already used by "{0}". Please choose a different key combination.</value>
+  </data>
+  <data name="HotkeyInvalidErrorMessage" xml:space="preserve">
+    <value>Invalid hotkey combination. Please include at least one non-modifier key (e.g., a letter, number, or function key).</value>
+  </data>
+  <data name="PowerToysConflict_Content" xml:space="preserve">
+    <value>PowerToys Light Switch is active and may conflict with Auto Dark Mode. Disable it in PowerToys settings to avoid unexpected theme switching.</value>
+  </data>
+  <data name="PowerToysConflict_Title" xml:space="preserve">
+    <value>PowerToys Light Switch detected</value>
+  </data>
   <data name="AmbientLightSensor" xml:space="preserve">
     <value>Ambient light sensor</value>
   </data>
@@ -1124,5 +1124,12 @@ Please note: This may introduce slight to moderate lag on some systems during th
   </data>
   <data name="Contributors" xml:space="preserve">
     <value>Contributors</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Release notes</value>
+    <comment>text on hyperlink (noun)</comment>
+  </data>
+  <data name="LatestRelease" xml:space="preserve">
+    <value>Latest official release</value>
   </data>
 </root>

--- a/AutoDarkModeApp/Views/AboutPage.xaml
+++ b/AutoDarkModeApp/Views/AboutPage.xaml
@@ -36,17 +36,35 @@
 
                 <!--  Version information  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=About}" />
-                <controls:SettingsExpander HeaderIcon="{ui:FontIcon Glyph=&#xe946;}" IsExpanded="True">
+                <controls:SettingsExpander HeaderIcon="{ui:BitmapIcon Source=/Assets/AutoDarkModeIcon.ico}" IsExpanded="True">
                     <controls:SettingsExpander.Header>
-                        <TextBlock>
-                            <Run Text="{helpers:ResourceString Name=Version}" />
-                            <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind ViewModel.SvcVersionText, Mode=OneWay}" />
-                        </TextBlock>
+                        <StackPanel Spacing="4">
+                            <TextBlock Margin="0,0,0,8">
+                                <Run Text="{helpers:ResourceString Name=Version}" />
+                                <Run Text="{x:Bind ViewModel.SvcVersionText}" />
+                            </TextBlock>
+                            <TextBlock Text="{helpers:ResourceString Name=LatestRelease}" />
+                            <TextBlock Margin="12,0,0,0">
+                                <Run>•</Run>
+                                <Run x:Name="ReleaseVersionTextBlock" />
+                                <Run>-</Run>
+                                <Run x:Name="ReleaseTypeTextBlock" />
+                                <Run>-</Run>
+                                <Run x:Name="ReleaseDateTextBlock" />
+                            </TextBlock>
+                            <TextBlock Margin="12,0,0,0">
+                                <Run>•</Run>
+                                <Hyperlink x:Name="ReleaseUrlHyperlink">
+                                    <Run Text="{helpers:ResourceString Name=ReleaseNotes}" />
+                                </Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
                     </controls:SettingsExpander.Header>
                     <Button
                         x:Name="CopyVersionInfoButton"
                         Click="CopyVersionInfoButton_Click"
                         Content="{helpers:ResourceString Name=Copy}" />
+
                     <controls:SettingsExpander.Items>
                         <controls:SettingsCard ContentAlignment="Left">
                             <StackPanel Orientation="Horizontal" Spacing="24">

--- a/AutoDarkModeApp/Views/AboutPage.xaml
+++ b/AutoDarkModeApp/Views/AboutPage.xaml
@@ -38,27 +38,33 @@
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="{helpers:ResourceString Name=About}" />
                 <controls:SettingsExpander HeaderIcon="{ui:BitmapIcon Source=/Assets/AutoDarkModeIcon.ico}" IsExpanded="True">
                     <controls:SettingsExpander.Header>
-                        <StackPanel Spacing="4">
-                            <TextBlock Margin="0,0,0,8">
-                                <Run Text="{helpers:ResourceString Name=Version}" />
-                                <Run Text="{x:Bind ViewModel.SvcVersionText}" />
-                            </TextBlock>
-                            <TextBlock Text="{helpers:ResourceString Name=LatestRelease}" />
-                            <TextBlock Margin="12,0,0,0">
-                                <Run>•</Run>
-                                <Run x:Name="ReleaseVersionTextBlock" />
-                                <Run>-</Run>
-                                <Run x:Name="ReleaseTypeTextBlock" />
-                                <Run>-</Run>
-                                <Run x:Name="ReleaseDateTextBlock" />
-                            </TextBlock>
-                            <TextBlock Margin="12,0,0,0">
-                                <Run>•</Run>
-                                <Hyperlink x:Name="ReleaseUrlHyperlink">
-                                    <Run Text="{helpers:ResourceString Name=ReleaseNotes}" />
-                                </Hyperlink>
-                            </TextBlock>
-                        </StackPanel>
+                        <Grid>
+                            <StackPanel x:Name="ReleaseInfoPanel" Spacing="4">
+                                <TextBlock Margin="0,0,0,8">
+                                    <Run Text="{helpers:ResourceString Name=Version}" />
+                                    <Run Text="{x:Bind ViewModel.SvcVersionText}" />
+                                </TextBlock>
+                                <TextBlock Text="{helpers:ResourceString Name=LatestRelease}" />
+                                <TextBlock Margin="12,0,0,0">
+                                    <Run>•</Run>
+                                    <Run x:Name="ReleaseVersionTextBlock" />
+                                    <Run>-</Run>
+                                    <Run x:Name="ReleaseTypeTextBlock" />
+                                    <Run>-</Run>
+                                    <Run x:Name="ReleaseDateTextBlock" />
+                                </TextBlock>
+                                <TextBlock Margin="12,0,0,0">
+                                    <Run>•</Run>
+                                    <Hyperlink x:Name="ReleaseUrlHyperlink">
+                                        <Run Text="{helpers:ResourceString Name=ReleaseNotes}" />
+                                    </Hyperlink>
+                                </TextBlock>
+                            </StackPanel>
+                            <TextBlock
+                                x:Name="ReleaseFallbackText"
+                                Text="{helpers:ResourceString Name=ReleaseInfoUnavailable}"
+                                Visibility="Collapsed" />
+                        </Grid>
                     </controls:SettingsExpander.Header>
                     <Button
                         x:Name="CopyVersionInfoButton"

--- a/AutoDarkModeApp/Views/AboutPage.xaml.cs
+++ b/AutoDarkModeApp/Views/AboutPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Text;
 using AutoDarkModeApp.ViewModels;
+using AutoDarkModeApp.Services;
 
 using AdmExtensions = AutoDarkModeLib.Helper;
 
@@ -9,6 +10,7 @@ namespace AutoDarkModeApp.Views;
 public sealed partial class AboutPage : Page
 {
     private readonly IErrorService errorService = App.GetService<IErrorService>();
+    private readonly IGitHubReleaseService _releaseService = new GitHubReleaseService();
 
     public AboutViewModel ViewModel { get; }
 
@@ -16,6 +18,21 @@ public sealed partial class AboutPage : Page
     {
         ViewModel = App.GetService<AboutViewModel>();
         InitializeComponent();
+        LoadReleaseInfoAsync();
+    }
+
+    private async void LoadReleaseInfoAsync()
+    {
+        var svcVersion = ViewModel?.SvcVersionText ?? string.Empty;
+        var release = await _releaseService.GetReleaseForVersionAsync(svcVersion);
+        if (release != null)
+        {
+            //ReleaseNameTextBlock.Text = release.Name;
+            ReleaseVersionTextBlock.Text = release.TagName;
+            ReleaseDateTextBlock.Text = release.PublishedAt.ToString("yyyy-MM-dd");
+            ReleaseTypeTextBlock.Text = release.IsPrerelease ? "Beta" : "Stable";
+            ReleaseUrlHyperlink.NavigateUri = new Uri(release.HtmlUrl);
+        }
     }
 
     private void CopyVersionInfoButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -144,4 +161,5 @@ public sealed partial class AboutPage : Page
             errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "AboutPage_GoToDocumentation");
         }
     }
+
 }

--- a/AutoDarkModeApp/Views/AboutPage.xaml.cs
+++ b/AutoDarkModeApp/Views/AboutPage.xaml.cs
@@ -33,6 +33,8 @@ public sealed partial class AboutPage : Page
             ReleaseTypeTextBlock.Text = release.IsPrerelease ? "Beta" : "Stable";
             ReleaseUrlHyperlink.NavigateUri = new Uri(release.HtmlUrl);
         }
+        ReleaseInfoPanel.Visibility = release != null ? Visibility.Visible : Visibility.Collapsed;
+        ReleaseFallbackText.Visibility = release == null ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void CopyVersionInfoButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)


### PR DESCRIPTION
Added info:

- latest official release number (note: fallback to Stable if current `SvcVersionText` is not a release)
- release type (beta/stable)
- release date
- link to release notes

<img width="427" height="378" alt="image" src="https://github.com/user-attachments/assets/95b2051f-57d1-487d-9643-a49776012906" />
