### PR TITLE
Fix: NavigationView Header gets cut off

### DIFF
--- a/AutoDarkModeApp/MainWindow.xaml
+++ b/AutoDarkModeApp/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:helpers="using:AutoDarkModeApp.Helpers"
     xmlns:local="using:AutoDarkModeApp"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:navigationService="using:AutoDarkModeApp.Services"
+    xmlns:models="using:AutoDarkModeApp.Models"
     xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
     <Window.SystemBackdrop>
@@ -33,7 +33,6 @@
         <NavigationView
             x:Name="NavigationViewControl"
             Grid.Row="1"
-            CompactModeThresholdWidth="0"
             IsBackButtonVisible="Collapsed"
             IsPaneToggleButtonVisible="False"
             IsSettingsVisible="True"
@@ -42,11 +41,14 @@
             <NavigationView.Header>
                 <BreadcrumbBar x:Name="BreadcrumBarControl" MaxWidth="{StaticResource PageContentMaxWidth}">
                     <BreadcrumbBar.ItemTemplate>
-                        <DataTemplate x:DataType="navigationService:BreadcrumbItem">
+                        <DataTemplate x:DataType="models:BreadcrumbItem">
                             <BreadcrumbBarItem AutomationProperties.Name="{Binding Content}" Content="{Binding}">
                                 <BreadcrumbBarItem.ContentTemplate>
                                     <DataTemplate>
-                                        <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{Binding Content}" />
+                                        <TextBlock
+                                            Padding="{Binding BreadcrumbBarTextBlockPadding}"
+                                            Style="{StaticResource TitleTextBlockStyle}"
+                                            Text="{Binding Content}" />
                                     </DataTemplate>
                                 </BreadcrumbBarItem.ContentTemplate>
                             </BreadcrumbBarItem>

--- a/AutoDarkModeApp/Models/BreadcrumbItem.cs
+++ b/AutoDarkModeApp/Models/BreadcrumbItem.cs
@@ -1,0 +1,12 @@
+﻿namespace AutoDarkModeApp.Models;
+
+public partial class BreadcrumbItem : ObservableObject
+{
+    public BreadcrumbItem() { }
+
+    public object? Content { get; set; }
+    public object? Tag { get; set; }
+
+    [ObservableProperty]
+    public partial Thickness BreadcrumbBarTextBlockPadding { get; set; }
+}

--- a/AutoDarkModeApp/Services/NavigationService.cs
+++ b/AutoDarkModeApp/Services/NavigationService.cs
@@ -36,6 +36,7 @@ public class NavigationService : INavigationService
     {
         _navigationView = navigationView;
         _navigationView.SelectionChanged += OnSelectionChanged;
+        _navigationView.DisplayModeChanged += DislplayModeChanged;
 
         _navigationView.PointerPressed += NavigationView_PointerPressed;
         _navigationView.KeyboardAccelerators.Add(BuildKeyboardAccelerator(VirtualKey.Left, VirtualKeyModifiers.Menu));
@@ -88,6 +89,24 @@ public class NavigationService : INavigationService
         {
             pageKey = "AutoDarkModeApp.ViewModels." + pageKey + "ViewModel";
             NavigateTo(pageKey);
+        }
+    }
+
+    private void DislplayModeChanged(NavigationView sender, NavigationViewDisplayModeChangedEventArgs args)
+    {
+        if (args.DisplayMode == NavigationViewDisplayMode.Minimal)
+        {
+            foreach (var item in _breadcrumbItems)
+            {
+                item.BreadcrumbBarTextBlockPadding = new Thickness(48, 0, 0, 0);
+            }
+        }
+        else
+        {
+            foreach (var item in _breadcrumbItems)
+            {
+                item.BreadcrumbBarTextBlockPadding = new Thickness(0, 0, 0, 0);
+            }
         }
     }
 
@@ -291,10 +310,4 @@ public class NavigationService : INavigationService
             }
         }
     }
-}
-
-public class BreadcrumbItem
-{
-    public object? Content { get; set; }
-    public object? Tag { get; set; }
 }

--- a/AutoDarkModeApp/Views/PersonalizationPage.xaml.cs
+++ b/AutoDarkModeApp/Views/PersonalizationPage.xaml.cs
@@ -19,7 +19,7 @@ public sealed partial class PersonalizationPage : Page
         {
             navigation.RegisterCustomBreadcrumbBarItem(
                 typeof(WallpaperPickerViewModel).FullName!,
-                new Services.BreadcrumbItem() { Content = "Background".GetLocalized(), Tag = "WallpaperPicker" }
+                new Models.BreadcrumbItem() { Content = "Background".GetLocalized(), Tag = "WallpaperPicker" }
             );
             navigation.NavigateTo(typeof(WallpaperPickerViewModel).FullName!);
         }
@@ -32,7 +32,7 @@ public sealed partial class PersonalizationPage : Page
         {
             navigation.RegisterCustomBreadcrumbBarItem(
                 typeof(ColorizationViewModel).FullName!,
-                new Services.BreadcrumbItem() { Content = "AccentColor".GetLocalized(), Tag = "Colorization" }
+                new Models.BreadcrumbItem() { Content = "AccentColor".GetLocalized(), Tag = "Colorization" }
             );
             navigation.NavigateTo(typeof(ColorizationViewModel).FullName!);
         }
@@ -45,7 +45,7 @@ public sealed partial class PersonalizationPage : Page
         {
             navigation.RegisterCustomBreadcrumbBarItem(
                 typeof(CursorsViewModel).FullName!,
-                new Services.BreadcrumbItem() { Content = "Cursors".GetLocalized(), Tag = "Cursors" }
+                new Models.BreadcrumbItem() { Content = "Cursors".GetLocalized(), Tag = "Cursors" }
             );
             navigation.NavigateTo(typeof(CursorsViewModel).FullName!);
         }
@@ -58,7 +58,7 @@ public sealed partial class PersonalizationPage : Page
         {
             navigation.RegisterCustomBreadcrumbBarItem(
                 typeof(ThemePickerViewModel).FullName!,
-                new Services.BreadcrumbItem() { Content = "Theme".GetLocalized(), Tag = "ThemePicker" }
+                new Models.BreadcrumbItem() { Content = "Theme".GetLocalized(), Tag = "ThemePicker" }
             );
             navigation.NavigateTo(typeof(ThemePickerViewModel).FullName!);
         }


### PR DESCRIPTION
### Description

This PR fixes a bug in WinUI itself where the navigation bar header was cut off; compared to the previous PR, this should be a more effective solution.

### Screenshots

<img width="928" height="698" alt="4f78b8cd58936a9ad08b53536e482282" src="https://github.com/user-attachments/assets/5e858818-3c0f-49fe-ab47-ad2835d8ed6e" />

### Supplement

I think it’s the right approach not to restrict the navigation bar. Even though we’ve limited the window size, who knows if someone might use some weird resolution or scaling level? (っ °Д °;)っ