### PR TITLE
fix: filter process suggestions while typing

### DIFF
--- a/AutoDarkModeApp/Views/ConditionsPage.xaml
+++ b/AutoDarkModeApp/Views/ConditionsPage.xaml
@@ -65,7 +65,7 @@
                                 TextChanged="ProcessTokenizingTextBox_TextChanged"
                                 TokenDelimiter=","
                                 TokenItemAdded="ProcessTokenizingTextBox_TokenItemChanged"
-                                TokenItemRemoved="ProcessTokenizingTextBox_TokenItemChanged" />
+                                TokenItemRemoved="ProcessTokenizingTextBox_TokenItemRemoved" />
                         </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
 

--- a/AutoDarkModeApp/Views/ConditionsPage.xaml
+++ b/AutoDarkModeApp/Views/ConditionsPage.xaml
@@ -62,6 +62,7 @@
                                 QueryIcon="{ui:FontIconSource Glyph=&#xE710;,
                                                               FontSize=12}"
                                 SuggestedItemsSource="{x:Bind ViewModel.ProcessListItemSource, Mode=OneWay}"
+                                TextChanged="ProcessTokenizingTextBox_TextChanged"
                                 TokenDelimiter=","
                                 TokenItemAdded="ProcessTokenizingTextBox_TokenItemChanged"
                                 TokenItemRemoved="ProcessTokenizingTextBox_TokenItemChanged" />

--- a/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
@@ -52,6 +52,17 @@ public sealed partial class ConditionsPage : Page
         }
     }
 
+    private void ProcessTokenizingTextBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
+            return;
+
+        sender.ItemsSource = ViewModel.ProcessListItemSource?
+            .Where(process => process.Contains(sender.Text, StringComparison.OrdinalIgnoreCase)
+                && ViewModel.ProcessBlockListItemSource?.Contains(process) != true)
+            .ToList();
+    }
+
     private void ProcessTokenizingTextBox_TokenItemChanged(CommunityToolkit.WinUI.Controls.TokenizingTextBox sender, object args)
     {
         if (ViewModel.ProcessBlockListItemSource == null)

--- a/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
@@ -82,4 +82,10 @@ public sealed partial class ConditionsPage : Page
             _errorService.ShowErrorMessage(ex, App.MainWindow.Content.XamlRoot, "SwitchModesPage");
         }
     }
+
+    private async void ProcessTokenizingTextBox_TokenItemRemoved(CommunityToolkit.WinUI.Controls.TokenizingTextBox sender, object args)
+    {
+        ProcessTokenizingTextBox_TokenItemChanged(sender, args);
+        await BuildProcessListAsync();
+    }
 }

--- a/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
+++ b/AutoDarkModeApp/Views/ConditionsPage.xaml.cs
@@ -59,7 +59,7 @@ public sealed partial class ConditionsPage : Page
 
         sender.ItemsSource = ViewModel.ProcessListItemSource?
             .Where(process => process.Contains(sender.Text, StringComparison.OrdinalIgnoreCase)
-                && ViewModel.ProcessBlockListItemSource?.Contains(process) != true)
+                && ViewModel.ProcessBlockListItemSource?.Contains(process, StringComparer.OrdinalIgnoreCase) != true)
             .ToList();
     }
 


### PR DESCRIPTION
Address the filtering portion of #1105 using TokenizingTextBox's public TextChanged event. Match process names case-insensitively and omit already selected processes without modifying the source list.